### PR TITLE
feat(keeperhub): add skill for web3 workflow automation via x402

### DIFF
--- a/mcp/skills/agentcash-wallet/SKILL.md
+++ b/mcp/skills/agentcash-wallet/SKILL.md
@@ -5,8 +5,8 @@ description: |
   If the task matches a SERVICES origin below, SKIP search and go straight to discover → fetch.
   Only search when NO listed origin fits.
 
-  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation).
-  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
+  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation), keeperhub (web3 workflows: DeFi yield/risk reads, on-chain checks, tipping).
+  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash, web3, defi, on-chain
 homepage: https://agentcash.dev
 metadata:
   version: 2.2
@@ -112,6 +112,7 @@ Payment is automatic: sends request, gets 402 challenge, signs USDC payment, ret
 | `https://stableemail.dev` | StableEmail | Send emails ($0.02), forwarding inboxes ($1/mo), custom subdomains ($5), programmatic mailboxes |
 | `https://stablephone.dev` | StablePhone | AI phone calls ($0.54), phone numbers ($20), top-ups ($15), iMessage/FaceTime lookup ($0.05) |
 | `https://stablejobs.dev` | StableJobs | Job search via Coresignal |
+| `https://app.keeperhub.com` | KeeperHub | Web3 workflow automation: DeFi yield/risk reads (Aave/Compound), on-chain health checks, tipping primitives, and write-type workflows that return unsigned calldata for the caller to sign |
 
 Run `agentcash.discover_api_endpoints(url="<origin>")` on any origin to see its full endpoint catalog.
 

--- a/mcp/skills/keeperhub/SKILL.md
+++ b/mcp/skills/keeperhub/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: keeperhub
+description: |
+  Web3 workflow automation via x402 payments. Read DeFi yield/risk data, check on-chain account health, and send tips on Base.
+
+  USE FOR:
+  - Comparing USDC yield rates across DeFi protocols (Aave vs Compound)
+  - Checking the health factor and risk level of an Aave v3 account
+  - Sending micropayments to an Ethereum address (microtip)
+  - Triggering KeeperHub workflows that wrap multi-step on-chain reads or RPC calls
+  - Discovering which workflows are available at runtime
+
+  TRIGGERS:
+  - "yield rates", "compare aave compound", "best stablecoin yield"
+  - "health factor", "aave health", "liquidation risk"
+  - "tip", "send a small payment", "microtip"
+  - "on-chain check", "defi risk", "web3 workflow"
+  - "keeperhub", "keeper workflow"
+
+  ALWAYS use `agentcash.fetch` for app.keeperhub.com endpoints.
+
+  IMPORTANT: Workflows are addressed by slug under `/api/mcp/workflows/{slug}/call`. Always discover available workflows first — the catalog and pricing change. Paid workflows return HTTP 402 on the first call; agentcash handles payment automatically and replays.
+metadata:
+  version: 1
+---
+
+# KeeperHub — Web3 Workflow Automation
+
+Run DeFi reads, on-chain health checks, and tipping primitives via x402 payments at `https://app.keeperhub.com`. USDC on Base mainnet. No account, no API key.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| Discover workflows (list) | `https://app.keeperhub.com/api/mcp/workflows` | Free |
+| Discover workflows (full schema) | `https://app.keeperhub.com/openapi.json` | Free |
+| Compare USDC yield (Aave vs Compound) | `https://app.keeperhub.com/api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call` | $0.01 |
+| Check Aave v3 account health | `https://app.keeperhub.com/api/mcp/workflows/aave-v3-health-check/call` | $0.01 |
+| Send a micropayment (microtip) | `https://app.keeperhub.com/api/mcp/workflows/microtip/call` | $0.01 |
+
+Network: Base mainnet. All paid workflows settle on success only — failed responses (4xx/5xx) cost nothing.
+
+All workflow calls return JSON with `executionId`, `status`, and an `output` payload. The shape of `output.result` is per-workflow — check the OpenAPI spec or the response itself.
+
+## Discover what's available
+
+```mcp
+agentcash.fetch(url="https://app.keeperhub.com/api/mcp/workflows")
+```
+
+Returns the full list of listed workflows: slug, description, price, and which ones are free. Use this before guessing — KeeperHub adds and removes workflows over time.
+
+For full per-workflow request/response schemas:
+
+```mcp
+agentcash.fetch(url="https://app.keeperhub.com/openapi.json")
+```
+
+Or use the agentcash discovery shorthand:
+
+```mcp
+agentcash.discover_api_endpoints(url="https://app.keeperhub.com")
+```
+
+## Compare USDC yield rates (Aave vs Compound)
+
+```mcp
+agentcash.fetch(
+  url="https://app.keeperhub.com/api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call",
+  method="POST",
+  body={}
+)
+```
+
+Response shape:
+
+```json
+{
+  "executionId": "exec_...",
+  "status": "success",
+  "output": {
+    "result": {
+      "rates": [
+        {"protocol": "aave-v3", "supplyApy": 0.0412, "borrowApy": 0.0521},
+        {"protocol": "compound-v3", "supplyApy": 0.0398, "borrowApy": 0.0487}
+      ],
+      "bestRate": 0.0412,
+      "bestProtocol": "aave-v3"
+    }
+  }
+}
+```
+
+No inputs required — the workflow reads current rates from chain. Use this when the user wants a real-time yield comparison.
+
+## Check Aave v3 account health
+
+```mcp
+agentcash.fetch(
+  url="https://app.keeperhub.com/api/mcp/workflows/aave-v3-health-check/call",
+  method="POST",
+  body={"address": "0x..."}
+)
+```
+
+Response shape:
+
+```json
+{
+  "executionId": "exec_...",
+  "status": "success",
+  "output": {
+    "result": {
+      "healthFactor": 1.84,
+      "totalCollateralUSD": 12500.0,
+      "totalDebtUSD": 5200.0,
+      "riskLevel": "moderate"
+    }
+  }
+}
+```
+
+`address` is the Aave v3 borrower's wallet address (any chain Aave v3 supports). `riskLevel` is one of `"safe" | "moderate" | "risky" | "liquidatable"`. Use this before the user takes a position or to monitor an existing one.
+
+## Send a micropayment (microtip)
+
+A tipping primitive that emits a small USDC transfer on Base. The exact request body shape isn't yet declared in `/openapi.json`, so check it before calling:
+
+```mcp
+agentcash.check_endpoint_schema(url="https://app.keeperhub.com/api/mcp/workflows/microtip/call")
+```
+
+Then call it via:
+
+```mcp
+agentcash.fetch(
+  url="https://app.keeperhub.com/api/mcp/workflows/microtip/call",
+  method="POST",
+  body={ ... see check output ... }
+)
+```
+
+Some tipping/write-type workflows return unsigned calldata in `output.result` for the caller to sign and broadcast separately; others settle the on-chain action via the same x402 payment. The OpenAPI 402 example for the workflow shows which mode it uses.
+
+## Failure modes
+
+- `402` on first call — expected. agentcash handles payment automatically and replays.
+- `400` — schema error on request body. Check the per-workflow `requestBody` field at `/openapi.json`.
+- `404` — workflow slug doesn't exist. Re-list `/api/mcp/workflows` for the current catalog.
+- `5xx` from the workflow — upstream RPC or DeFi protocol issue. No settlement on failure. Safe to retry.
+
+## When to use KeeperHub vs other origins
+
+- **Use KeeperHub** for live DeFi reads, on-chain account checks, and on-chain payments wrapped as named workflows.
+- **Use stableenrich** for off-chain people/company research, web search, and scraping.
+- **Use stablesocial** for social-platform data.
+
+## Learn more
+
+- Homepage: https://keeperhub.com
+- Docs: https://docs.keeperhub.com
+- OpenAPI spec: https://app.keeperhub.com/openapi.json

--- a/mcp/skills/keeperhub/rules/getting-started.md
+++ b/mcp/skills/keeperhub/rules/getting-started.md
@@ -1,0 +1,39 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash MCP server** (if not already installed):
+   ```bash
+   npx agentcash@latest install -y
+   ```
+
+2. **Check wallet:**
+   ```mcp
+   agentcash.get_balance()
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `agentcash.redeem_invite(code="YOUR_CODE")`
+   - Or call `agentcash.list_accounts()` to get Base or Solana deposit links and wallet addresses
+
+KeeperHub workflows settle on **Base mainnet (USDC)**. Make sure the wallet has Base USDC before calling paid workflows.
+
+## Pricing reference
+
+Most read-type DeFi workflows are $0.01. Tipping and write-type workflows vary — always discover before calling:
+
+```mcp
+agentcash.fetch(url="https://app.keeperhub.com/api/mcp/workflows")
+```
+
+The `/api/mcp/workflows` listing returns up-to-date pricing per slug.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Insufficient balance" | Fund wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient errors) |
+| `404` from workflow slug | Re-list `/api/mcp/workflows` — catalog changes |
+| `400 Bad Request` | Verify input schema at `/openapi.json` for that workflow's `requestBody` |
+| "405 Method Not Allowed" | All workflow calls are POST. Set `method="POST"`. |

--- a/plugin/skills/agentcash/SKILL.md
+++ b/plugin/skills/agentcash/SKILL.md
@@ -5,8 +5,8 @@ description: |
   If the task matches a SERVICES origin below, SKIP search and go straight to discover → fetch.
   Only search when NO listed origin fits.
 
-  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation).
-  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
+  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation), keeperhub (web3 workflows: DeFi yield/risk reads, on-chain checks, tipping).
+  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash, web3, defi, on-chain
 homepage: https://agentcash.dev
 metadata:
   version: 2.2
@@ -104,6 +104,7 @@ Payment is automatic: sends request, gets 402 challenge, signs USDC payment, ret
 | `https://stablejobs.dev` | StableJobs | Job search via Coresignal |
 | `https://stabletravel.dev` | StableTravel | Travel search via Amadeus |
 | `https://stablebrowser.dev` | StableBrowser | Browser Use |
+| `https://app.keeperhub.com` | KeeperHub | Web3 workflow automation: DeFi yield/risk reads (Aave/Compound), on-chain health checks, tipping primitives, and write-type workflows that return unsigned calldata for the caller to sign |
 
 Run `agentcash.discover_api_endpoints(url="<origin>")` on any origin to see its full endpoint catalog.
 

--- a/skills/agentcash/SKILL.md
+++ b/skills/agentcash/SKILL.md
@@ -5,8 +5,8 @@ description: |
   If the task matches a SERVICES origin below, SKIP search and go straight to discover → fetch.
   Only search when NO listed origin fits.
 
-  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation).
-  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
+  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation), keeperhub (web3 workflows: DeFi yield/risk reads, on-chain checks, tipping).
+  TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash, web3, defi, on-chain
 homepage: https://agentcash.dev
 metadata:
   version: 2.2
@@ -108,6 +108,7 @@ Any endpoint that is payment-protected can be accessed with AgentCash. If `npx a
 | `stablephone.dev` | AI phone calls ($0.54), phone numbers ($20), top-ups ($15), iMessage/FaceTime lookup ($0.05) |
 | `stablejobs.dev` | Job search via Coresignal |
 | `stabletravel.dev` | Travel search |
+| `app.keeperhub.com` | Web3 workflow automation: DeFi yield/risk reads (Aave/Compound), on-chain health checks, tipping primitives, and write-type workflows that return unsigned calldata for the caller to sign |
 
 There are many more services available beyond the ones listed here.
 

--- a/skills/keeperhub/SKILL.md
+++ b/skills/keeperhub/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: keeperhub
+description: |
+  Web3 workflow automation via x402 payments. Read DeFi yield/risk data, check on-chain account health, and send tips on Base.
+
+  USE FOR:
+  - Comparing USDC yield rates across DeFi protocols (Aave vs Compound)
+  - Checking the health factor and risk level of an Aave v3 account
+  - Sending micropayments to an Ethereum address (microtip)
+  - Triggering KeeperHub workflows that wrap multi-step on-chain reads or RPC calls
+  - Discovering which workflows are available at runtime
+
+  TRIGGERS:
+  - "yield rates", "compare aave compound", "best stablecoin yield"
+  - "health factor", "aave health", "liquidation risk"
+  - "tip", "send a small payment", "microtip"
+  - "on-chain check", "defi risk", "web3 workflow"
+  - "keeperhub", "keeper workflow"
+
+  ALWAYS use `npx agentcash@latest fetch` for app.keeperhub.com endpoints.
+
+  IMPORTANT: Workflows are addressed by slug under `/api/mcp/workflows/{slug}/call`. Always discover available workflows first — the catalog and pricing change. Paid workflows return HTTP 402 on the first call; agentcash handles payment automatically and replays.
+metadata:
+  version: 1
+---
+
+# KeeperHub — Web3 Workflow Automation
+
+Run DeFi reads, on-chain health checks, and tipping primitives via x402 payments at `https://app.keeperhub.com`. USDC on Base mainnet. No account, no API key.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| Discover workflows (list) | `https://app.keeperhub.com/api/mcp/workflows` | Free |
+| Discover workflows (full schema) | `https://app.keeperhub.com/openapi.json` | Free |
+| Compare USDC yield (Aave vs Compound) | `https://app.keeperhub.com/api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call` | $0.01 |
+| Check Aave v3 account health | `https://app.keeperhub.com/api/mcp/workflows/aave-v3-health-check/call` | $0.01 |
+| Send a micropayment (microtip) | `https://app.keeperhub.com/api/mcp/workflows/microtip/call` | $0.01 |
+
+Network: Base mainnet. All paid workflows settle on success only — failed responses (4xx/5xx) cost nothing.
+
+All workflow calls return JSON with `executionId`, `status`, and an `output` payload. The shape of `output.result` is per-workflow — check the OpenAPI spec or the response itself.
+
+## Discover what's available
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/api/mcp/workflows
+```
+
+Returns the full list of listed workflows: slug, description, price, and which ones are free. Use this before guessing — KeeperHub adds and removes workflows over time.
+
+For full per-workflow request/response schemas:
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/openapi.json
+```
+
+Or use the agentcash discovery shorthand:
+
+```bash
+npx agentcash@latest discover https://app.keeperhub.com
+```
+
+## Compare USDC yield rates (Aave vs Compound)
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call \
+  -m POST \
+  -b '{}'
+```
+
+Response shape:
+
+```json
+{
+  "executionId": "exec_...",
+  "status": "success",
+  "output": {
+    "result": {
+      "rates": [
+        {"protocol": "aave-v3", "supplyApy": 0.0412, "borrowApy": 0.0521},
+        {"protocol": "compound-v3", "supplyApy": 0.0398, "borrowApy": 0.0487}
+      ],
+      "bestRate": 0.0412,
+      "bestProtocol": "aave-v3"
+    }
+  }
+}
+```
+
+No inputs required — the workflow reads current rates from chain. Use this when the user wants a real-time yield comparison.
+
+## Check Aave v3 account health
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/api/mcp/workflows/aave-v3-health-check/call \
+  -m POST \
+  -b '{
+  "address": "0x..."
+}'
+```
+
+Response shape:
+
+```json
+{
+  "executionId": "exec_...",
+  "status": "success",
+  "output": {
+    "result": {
+      "healthFactor": 1.84,
+      "totalCollateralUSD": 12500.0,
+      "totalDebtUSD": 5200.0,
+      "riskLevel": "moderate"
+    }
+  }
+}
+```
+
+`address` is the Aave v3 borrower's wallet address (any chain Aave v3 supports). `riskLevel` is one of `"safe" | "moderate" | "risky" | "liquidatable"`. Use this before the user takes a position or to monitor an existing one.
+
+## Send a micropayment (microtip)
+
+A tipping primitive that emits a small USDC transfer on Base. The exact request body shape isn't yet declared in `/openapi.json`, so check it before calling:
+
+```bash
+npx agentcash@latest check https://app.keeperhub.com/api/mcp/workflows/microtip/call
+```
+
+Then call it via:
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/api/mcp/workflows/microtip/call \
+  -m POST \
+  -b '{ ... see check output ... }'
+```
+
+Some tipping/write-type workflows return unsigned calldata in `output.result` for the caller to sign and broadcast separately; others settle the on-chain action via the same x402 payment. The OpenAPI 402 example for the workflow shows which mode it uses.
+
+## Failure modes
+
+- `402` on first call — expected. agentcash handles payment automatically and replays.
+- `400` — schema error on request body. Check the per-workflow `requestBody` field at `/openapi.json`.
+- `404` — workflow slug doesn't exist. Re-list `/api/mcp/workflows` for the current catalog.
+- `5xx` from the workflow — upstream RPC or DeFi protocol issue. No settlement on failure. Safe to retry.
+
+## When to use KeeperHub vs other origins
+
+- **Use KeeperHub** for live DeFi reads, on-chain account checks, and on-chain payments wrapped as named workflows.
+- **Use stableenrich** for off-chain people/company research, web search, and scraping.
+- **Use stablesocial** for social-platform data.
+
+## Learn more
+
+- Homepage: https://keeperhub.com
+- Docs: https://docs.keeperhub.com
+- OpenAPI spec: https://app.keeperhub.com/openapi.json

--- a/skills/keeperhub/rules/getting-started.md
+++ b/skills/keeperhub/rules/getting-started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+KeeperHub workflows settle on **Base mainnet (USDC)**. Make sure the wallet has Base USDC before calling paid workflows.
+
+## Pricing reference
+
+Most read-type DeFi workflows are $0.01. Tipping and write-type workflows vary — always discover before calling:
+
+```bash
+npx agentcash@latest fetch https://app.keeperhub.com/api/mcp/workflows
+```
+
+The `/api/mcp/workflows` listing returns up-to-date pricing per slug.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient errors) |
+| `404` from workflow slug | Re-list `/api/mcp/workflows` — catalog changes |
+| `400 Bad Request` | Verify input schema at `/openapi.json` for that workflow's `requestBody` |
+| "405 Method Not Allowed" | All workflow calls are POST. Use `-m POST`. |


### PR DESCRIPTION
## Summary

Adds a skill for **KeeperHub** (https://app.keeperhub.com) — a web3 workflow-automation platform that exposes DeFi reads, on-chain checks, and tipping primitives as named workflows callable via x402 (USDC on Base, $0.01 typical for reads).

| Area | Change |
|------|--------|
| `skills/keeperhub/` | New CLI-mode skill (mirrors `skills/email/` shape) |
| `mcp/skills/keeperhub/` | New MCP-mode skill |
| `skills/agentcash/SKILL.md` | Add `keeperhub` to SERVICES + Available Services table; add `web3, defi, on-chain` to TRIGGERS |
| `mcp/skills/agentcash-wallet/SKILL.md` | Same edits |
| `plugin/skills/agentcash/SKILL.md` | Same edits |

## Why now

KeeperHub just hardened its OpenAPI spec for x402/agentcash bazaar discoverability ([KeeperHub#1077](https://github.com/KeeperHub/keeperhub/pull/1077)) — every workflow now declares canonical `x-payment-info`, `extensions.bazaar.schema.{input,output}`, `security: []` on free routes, and a worked-examples block in `info.x-guidance`. With the spec corrected, KeeperHub now satisfies the same shape that the curated agentcash preamble assumes, so adding it to SERVICES gives agents a discoverable origin for web3 tasks (currently no listed origin covers DeFi / on-chain).

## Workflows surfaced

The `Quick Reference` table in the new skill lists the live workflows:

| Task | Endpoint | Price |
|------|----------|-------|
| Discover workflows (list) | `/api/mcp/workflows` | Free |
| Discover workflows (full schema) | `/openapi.json` | Free |
| Compare USDC yield (Aave vs Compound) | `/api/mcp/workflows/usdc-yield-rates-aave-vs-compound/call` | \$0.01 |
| Check Aave v3 account health | `/api/mcp/workflows/aave-v3-health-check/call` | \$0.01 |
| Send a micropayment (microtip) | `/api/mcp/workflows/microtip/call` | \$0.01 |

## Verification

Verified against the live KeeperHub OpenAPI spec at https://app.keeperhub.com/openapi.json:
- Workflow path pattern (`/api/mcp/workflows/{slug}/call`) and response envelope (`{executionId, status, output: {result}}`) match the canonical spec.
- `aave-v3-health-check` input (`{address}`) and output keys (`healthFactor`, `totalCollateralUSD`, `totalDebtUSD`, `riskLevel`) match.
- `usdc-yield-rates-aave-vs-compound` input shape (`{}`) and top-level output keys (`rates`, `bestRate`, `bestProtocol`) match.

Endpoints exercised live (paid settlement on Base) before this PR: ~\$0.04 across the three workflows above. All settlements succeeded; the pricing in the table reflects the real `x-payment-info.price` on each route.

## Notes for reviewers

- **microtip's input schema is not declared in `/openapi.json` yet** (workflow-side gap on KeeperHub's end, separate from this PR). Rather than invent an example body, the skill directs callers to `check_endpoint_schema` (MCP) / `npx agentcash@latest check` (CLI) first. The KeeperHub team has been notified and a backfill is on their side.
- The `plugin/` variant only ships the `agentcash` meta-skill (no per-service skill dirs), matching existing convention — so no `plugin/skills/keeperhub/` is added.
- Follows the bavlio (#8) shape for new-service contributions: `SKILL.md` + `rules/getting-started.md`, mirrored to `mcp/skills/`.

## Structure

```
skills/keeperhub/
├── SKILL.md
└── rules/getting-started.md
mcp/skills/keeperhub/
├── SKILL.md
└── rules/getting-started.md
```

Plus 3-line additions to each of the three top-level `agentcash` SKILL.md files.