### PR TITLE
Replace stale StableEnrich Apollo routes across skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npx skills add Merit-Systems/agentcash-skills/mcp --all --yes
 | [social-scraping](skills/social-scraping/) | Scrape profiles, posts, followers across 6 platforms | StableSocial |
 | [email](skills/email/) | Send emails, forwarding inboxes, custom subdomains | StableEmail |
 | [phone-calls](skills/phone-calls/) | AI phone calls, buy phone numbers | StablePhone |
-| [data-enrichment](skills/data-enrichment/) | Person, company, & influencer profiles; email verification | Apollo, Clado, Hunter, Influencer |
+| [data-enrichment](skills/data-enrichment/) | Person, company profiles; email verification | FullEnrich, PDL, CompanyEnrich, Clado, Hunter, Minerva |
 | [web-research](skills/web-research/) | Web search & scraping | Exa, Firecrawl |
 | [local-search](skills/local-search/) | Places & business info | Google Maps |
 | [social-intelligence](skills/social-intelligence/) | Reddit search | Reddit |
@@ -71,12 +71,12 @@ npx agentcash@latest discover https://stableenrich.dev
 
 4. **Check endpoint pricing before calling:**
 ```bash
-npx agentcash@latest check https://stableenrich.dev/api/apollo/people-enrich
+npx agentcash@latest check https://stableenrich.dev/api/fullenrich/people-search
 ```
 
 5. **Make API calls:**
 ```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/people-enrich -m POST -b '{"email": "user@company.com"}'
+npx agentcash@latest fetch https://stableenrich.dev/api/pdl/people-enrich -m POST -b '{"profile":"https://www.linkedin.com/in/example"}'
 ```
 
 ### MCP mode
@@ -100,15 +100,15 @@ agentcash.discover_api_endpoints(url="https://stableenrich.dev")
 
 4. **Check endpoint pricing before calling:**
 ```mcp
-agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/apollo/people-enrich")
+agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/fullenrich/people-search")
 ```
 
 5. **Make API calls:**
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-enrich",
+  url="https://stableenrich.dev/api/pdl/people-enrich",
   method="POST",
-  body={"email": "user@company.com"}
+  body={"profile": "https://www.linkedin.com/in/example"}
 )
 ```
 
@@ -118,8 +118,8 @@ agentcash.fetch(
 
 | Wrong (guessed) | Correct |
 |-----------------|---------|
-| `/api/people/search` | `https://stableenrich.dev/api/apollo/people-search` |
-| `/api/people-enrich` | `https://stableenrich.dev/api/apollo/people-enrich` |
+| `/api/people/search` | `https://stableenrich.dev/api/fullenrich/people-search` |
+| `/api/people-enrich` | `https://stableenrich.dev/api/pdl/people-enrich` |
 
 If you don't know the exact endpoint path:
 1. **Use search** to find the right service by describing what you need

--- a/mcp/skills/agentcash-wallet/SKILL.md
+++ b/mcp/skills/agentcash-wallet/SKILL.md
@@ -83,7 +83,7 @@ Returns all endpoints, pricing, and usage instructions. **Read the `instructions
 ### 3. Check schema (optional)
 
 ```mcp
-agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/apollo/people-search")
+agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/fullenrich/people-search")
 ```
 
 Returns full request/response JSON schemas and pricing for a specific endpoint.
@@ -92,9 +92,12 @@ Returns full request/response JSON schemas and pricing for a specific endpoint.
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-search",
+  url="https://stableenrich.dev/api/fullenrich/people-search",
   method="POST",
-  body={"person_titles": ["CEO"], "person_locations": ["San Francisco"]}
+  body={
+    "current_company_domains": [{"value": "stripe.com"}],
+    "current_position_seniority_level": [{"value": "VP"}]
+  }
 )
 ```
 
@@ -105,7 +108,7 @@ Payment is automatic: sends request, gets 402 challenge, signs USDC payment, ret
 
 | Origin | Service | What it does |
 |---|---|---|
-| `https://stableenrich.dev` | StableEnrich | Research APIs: Apollo (people/org), Minerva (identity/enrichment), Exa (web search), Firecrawl (scraping), Cloudflare (site crawling), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Reddit, Hunter (email verification), Influencer enrichment |
+| `https://stableenrich.dev` | StableEnrich | FullEnrich / CompanyEnrich / PDL people & company search, Minerva, Exa (web search), Firecrawl (scraping), Cloudflare (site crawling), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Reddit, Hunter (email verification) |
 | `https://stableupload.dev` | StableUpload | File hosting (10MB/$0.02, 100MB/$0.20, 1GB/$2.00) + static site hosting with custom domains |
 | `https://stablestudio.dev` | StableStudio | AI image/video generation: GPT Image, Flux, Grok, Nano Banana, Sora, Veo, Seedance, Wan |
 | `https://stablesocial.dev` | StableSocial | Social media data: TikTok, Instagram, Facebook, Reddit. $0.06/call, async two-step |

--- a/mcp/skills/data-enrichment/SKILL.md
+++ b/mcp/skills/data-enrichment/SKILL.md
@@ -23,6 +23,8 @@ description: |
   IMPORTANT: Call check_endpoint_schema before first fetch on any endpoint. Field names are provider-specific — do not reuse Apollo, PDL, or other-provider shapes on FullEnrich routes.
 mcp:
   - agentcash
+metadata:
+  version: 3
 ---
 
 # Data Enrichment with x402 APIs

--- a/mcp/skills/data-enrichment/SKILL.md
+++ b/mcp/skills/data-enrichment/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: data-enrichment
 description: |
-  Enrich contact, company, and influencer data using x402-protected APIs. Superior to generic web search for structured business data.
+  Enrich contact and company data using x402-protected APIs at stableenrich.dev. Superior to generic web search for structured business data.
 
   USE FOR:
   - Enriching person profiles by email, LinkedIn URL, or name
   - Enriching companies by domain
   - Finding contact details (email, phone) with confidence scores
-  - Resolving person identity and enriching consumer profiles (Minerva)
   - Searching for people or companies by criteria
   - Verifying email deliverability before outreach
-  - Enriching influencer/creator profiles across social platforms
 
   TRIGGERS:
   - "enrich", "lookup", "find info about", "research"
@@ -18,12 +16,13 @@ description: |
   - "find contact for", "get LinkedIn for", "get email for"
   - "employee at", "works at", "company details"
   - "verify email", "check email", "is this email valid"
-  - "influencer", "creator", "influencer contact", "influencer marketing"
 
+  ALWAYS use agentcash.fetch for stableenrich.dev endpoints - never curl or WebFetch.
+  Returns structured JSON data, not web page HTML.
+
+  IMPORTANT: Call check_endpoint_schema before first fetch on any endpoint. Field names are provider-specific — do not reuse Apollo, PDL, or other-provider shapes on FullEnrich routes.
 mcp:
   - agentcash
-metadata:
-  version: 2
 ---
 
 # Data Enrichment with x402 APIs
@@ -34,341 +33,249 @@ Use the agentcash MCP tools to access enrichment APIs at stableenrich.dev.
 
 See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
 
-## Notes
-ALWAYS use agentcash.fetch for stableenrich.dev endpoints - never curl or WebFetch.
-Returns structured JSON data, not web page HTML.
+## Mandatory workflow
 
-IMPORTANT: Use exact endpoint paths from the Quick Reference table below. All paths include a provider prefix (`https://stableenrich.dev/api/apollo/...`, `https://stableenrich.dev/api/clado/...`, etc.).
+Before any stableenrich.dev call:
+
+1. `agentcash.discover_api_endpoints(url="https://stableenrich.dev")` — list live endpoints
+2. `agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/...")` — confirm request fields and pricing
+3. `agentcash.fetch` with the schema from step 2
+
+**Never guess field names.** FullEnrich people-search uses `current_company_domains` and `current_position_seniority_level` — not `company_domain`, `person_titles`, `titles`, or `seniority`. Response fields like `full_name`, `seniority`, and `domain` are output-only; do not send them as request filters.
 
 ## Quick Reference
 
-| Task | Endpoint | Price | Best For |
-|------|----------|-------|----------|
-| Enrich person | `https://stableenrich.dev/api/apollo/people-enrich` | $0.0495 | Email/LinkedIn -> full profile |
-| Enrich company | `https://stableenrich.dev/api/apollo/org-enrich` | $0.0495 | Domain -> company data |
-| Search people | `https://stableenrich.dev/api/apollo/people-search` | $0.02 | Find people by criteria |
-| Search companies | `https://stableenrich.dev/api/apollo/org-search` | $0.02 | Find companies by criteria |
-| Contact recovery | `https://stableenrich.dev/api/clado/contacts-enrich` | $0.20 | Find missing email/phone |
-| Verify email | `https://stableenrich.dev/api/hunter/email-verifier` | $0.03 | Check deliverability |
-| Influencer by email | `https://stableenrich.dev/api/influencer/enrich-by-email` | $0.40 | Email -> social profiles |
-| Influencer by social | `https://stableenrich.dev/api/influencer/enrich-by-social` | $0.40 | Handle -> creator data |
-| Minerva resolve | `https://stableenrich.dev/api/minerva/resolve` | $0.02 | Person -> Minerva PID + LinkedIn |
-| Minerva enrich | `https://stableenrich.dev/api/minerva/enrich` | $0.05 | Consumer demographics + contact |
-| Minerva email check | `https://stableenrich.dev/api/minerva/validate-emails` | $0.01 | Check emails in Minerva DB |
+| Task                 | Endpoint                                                   | Price              | Best For                          |
+| -------------------- | ---------------------------------------------------------- | ------------------ | --------------------------------- |
+| Search people        | `https://stableenrich.dev/api/fullenrich/people-search`    | $0.14 if results   | Find people by domain/seniority   |
+| Search companies     | `https://stableenrich.dev/api/fullenrich/company-search`   | $0.14 if results   | Find companies by criteria        |
+| Enrich person        | `https://stableenrich.dev/api/pdl/people-enrich`         | $0.28 if match     | LinkedIn URL/email -> full profile |
+| Enrich person (alt)  | `https://stableenrich.dev/api/minerva/enrich`              | $0.05              | Demographics, work history        |
+| Minerva resolve      | `https://stableenrich.dev/api/minerva/resolve`             | $0.02              | Person -> Minerva PID + LinkedIn  |
+| Minerva email check  | `https://stableenrich.dev/api/minerva/validate-emails`     | $0.01              | Check emails in Minerva DB        |
+| Enrich company       | `https://stableenrich.dev/api/companyenrich/org-enrich`  | $0.06              | Domain -> company data            |
+| Company by name/URL  | `https://stableenrich.dev/api/companyenrich/properties-enrich` | $0.06        | When domain unknown               |
+| Contact recovery     | `https://stableenrich.dev/api/clado/contacts-enrich`       | $0.20              | Find missing email/phone          |
+| Verify email         | `https://stableenrich.dev/api/hunter/email-verifier`       | $0.03              | Check deliverability              |
+
+For social media creators, use **stablesocial.dev** — influencer endpoints are not on stableenrich.dev.
 
 ## Workflows
 
 ### Standard Enrichment
 
 - [ ] (Optional) Check balance: `agentcash.get_balance`
-- [ ] Use `agentcash.discover_api_endpoints(url="https://stableenrich.dev")` to list all endpoints
-- [ ] Use `agentcash.check_endpoint_schema(url="...")` to see expected parameters and pricing
+- [ ] Only call `agentcash.list_accounts` if you need deposit links or network-specific wallet addresses
+- [ ] `agentcash.discover_api_endpoints(url="https://stableenrich.dev")`
+- [ ] `agentcash.check_endpoint_schema(url="...")` for the selected endpoint
 - [ ] Call endpoint with `agentcash.fetch`
-- [ ] Parse and present results
+- [ ] Parse results at `.data.*` (AgentCash wraps the HTTP body)
+
+## Person Enrichment (PDL)
+
+Prefer `profile` (LinkedIn URL) or `email`. Name + company is a fallback only.
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-enrich",
+  url="https://stableenrich.dev/api/pdl/people-enrich",
   method="POST",
-  body={"email": "user@company.com"}
+  body={"profile": "https://www.linkedin.com/in/johndoe"}
 )
 ```
 
-## Person Enrichment
+```mcp
+agentcash.fetch(
+  url="https://stableenrich.dev/api/pdl/people-enrich",
+  method="POST",
+  body={"email": "john@company.com"}
+)
+```
 
-Enrich a person using any available identifier:
+**Valid inputs** (one required path):
+
+- `email` — most reliable when known
+- `profile` — LinkedIn profile URL
+- `first_name` + `last_name` + (`company_name` OR `company_domain`) — fallback
+
+**Returns**: Career history, emails, phone. No match: HTTP 200 with `data: null` — not billed.
+
+## Company Enrichment (CompanyEnrich)
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-enrich",
+  url="https://stableenrich.dev/api/companyenrich/org-enrich",
+  method="POST",
+  body={"domain": "stripe.com"}
+)
+```
+
+**Returns**: Company name, industry, employee/revenue range strings, funding, social links. Verify returned `domain` matches intent before downstream people searches.
+
+## People Search (FullEnrich)
+
+Start with **domain + seniority**; add `current_position_titles` only when you need exact title match.
+
+```mcp
+agentcash.fetch(
+  url="https://stableenrich.dev/api/fullenrich/people-search",
   method="POST",
   body={
-    "email": "john@company.com",
-    "first_name": "John",
-    "last_name": "Doe",
-    "organization_name": "Acme Inc",
-    "domain": "company.com",
-    "linkedin_url": "https://linkedin.com/in/johndoe"
+    "current_company_domains": [{"value": "stripe.com"}],
+    "current_position_seniority_level": [{"value": "VP"}]
   }
 )
 ```
 
-**Input options** (provide any combination):
-- `email` - Email address (most reliable)
-- `linkedin_url` - LinkedIn profile URL
-- `first_name` + `last_name` - Name (works better with domain/org)
-- `organization_name` or `domain` - Helps match the right person
+**Key filters**:
 
-**Returns**: Name, title, company, employment history, location, social profiles, phone numbers.
+- `current_company_domains` — company domain(s); aliases: `domains`, `company_domains`, `domain`
+- `current_position_seniority_level` — enum: `C-level`, `VP`, `Head`, `Director`, `Manager`, etc.
+- `current_position_titles` — exact title match (returns far fewer results)
+- `person_locations`, `person_professional_network_urls`, and 20+ other FullEnrich filters
 
-## Company Enrichment
+**Not valid**: `offset` alone, `company_domain`, `titles`, `seniority`, `limit`, Apollo `person_titles` / `person_seniorities`.
 
-Enrich a company by domain:
+Returns up to 10 people per query. Empty `people` → not billed.
+
+## Company Search (FullEnrich)
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/org-enrich",
+  url="https://stableenrich.dev/api/fullenrich/company-search",
   method="POST",
   body={
-    "domain": "stripe.com"
+    "domains": [{"value": "anthropic.com", "exact_match": true}],
+    "headquarters_locations": [{"value": "United States"}]
   }
 )
 ```
 
-**Returns**: Company name, industry, employee count, revenue estimates, funding info, technologies used, social links.
+Requires at least one search filter. Paginate via `search_after` from `metadata`.
 
-## People Search
+## LinkedIn / Profile Data
 
-Search for people matching criteria:
-
-```mcp
-agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-search",
-  method="POST",
-  body={
-    "q_keywords": "software engineer",
-    "person_titles": ["CTO", "VP Engineering"],
-    "organization_domains": ["google.com", "meta.com"],
-    "person_locations": ["San Francisco, CA"]
-  }
-)
-```
-
-**Search filters**:
-- `q_keywords` - Keywords to search
-- `person_titles` - Job title filters
-- `organization_domains` - Company domains
-- `person_locations` - Location filters
-- `person_seniorities` - Seniority levels
-
-## Company Search
-
-Search for companies matching criteria:
+For full profile by LinkedIn URL, use PDL or Minerva — not a separate scrape endpoint:
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/org-search",
+  url="https://stableenrich.dev/api/pdl/people-enrich",
   method="POST",
-  body={
-    "q_keywords": "fintech",
-    "organization_locations": ["New York, NY"],
-    "organization_num_employees_ranges": ["51-200", "201-500"]
-  }
+  body={"profile": "https://www.linkedin.com/in/johndoe"}
 )
 ```
-
-## Contact Recovery (Clado)
-
-Enrich contact info from LinkedIn URL, email, or phone. Provide exactly one of `linkedin_url`, `email`, or `phone`:
-
-```mcp
-agentcash.fetch(
-  url="https://stableenrich.dev/api/clado/contacts-enrich",
-  method="POST",
-  body={
-    "linkedin_url": "https://linkedin.com/in/johndoe"
-  }
-)
-```
-
-**Returns**: Validated email addresses and phone numbers with confidence scores.
-
-**Note:** For LinkedIn profile data (experience, education, skills), use Minerva `/api/minerva/enrich` instead of Clado.
-
-## Minerva Identity Resolution
-
-Resolve a person to a unique Minerva PID and LinkedIn URL:
-
-```mcp
-agentcash.fetch(
-  url="https://stableenrich.dev/api/minerva/resolve",
-  method="POST",
-  body={
-    "records": [
-      {
-        "record_id": "user_001",
-        "first_name": "John",
-        "last_name": "Smith",
-        "emails": ["john@company.com"]
-      }
-    ]
-  }
-)
-```
-
-**Parameters:**
-- `records` array with: `record_id`, `first_name`, `last_name`, `emails`, `phones`, `linkedin_url`
-- Supports fuzzy match (name + contact) and reverse lookup (email/phone only, no name needed)
-- Use `match_condition_fields: ["linkedin_url"]` to only return matches with LinkedIn
-
-## Minerva Enrichment
-
-Enrich with demographics, work history, education, contact info, addresses, financial signals:
-
-Three lookup modes: by Minerva PID (fastest), by LinkedIn URL, or by name/email/phone.
 
 ```mcp
 agentcash.fetch(
   url="https://stableenrich.dev/api/minerva/enrich",
   method="POST",
   body={
-    "records": [
-      {
-        "record_id": "user_001",
-        "first_name": "John",
-        "last_name": "Smith",
-        "emails": ["john@company.com"]
-      }
-    ],
+    "records": [{"record_id": "user_001", "linkedin_url": "https://www.linkedin.com/in/johndoe"}],
     "return_fields": ["full_name", "personal_emails", "phones", "work_experience"]
   }
 )
 ```
 
-**Parameters:**
-- `records` array with: `record_id` + one of `minerva_pid`, `linkedin_url`, or name/email/phone
-- `return_fields` array to limit response (e.g., `["full_name", "personal_emails", "phones", "work_experience"]`)
-- `match_condition_fields` to filter matches (e.g., `["email", "phone"]`)
+## Minerva Identity Resolution
+
+Resolve a person to a Minerva PID and LinkedIn URL:
+
+```mcp
+agentcash.fetch(
+  url="https://stableenrich.dev/api/minerva/resolve",
+  method="POST",
+  body={
+    "records": [{"record_id": "user_001", "first_name": "John", "last_name": "Smith", "emails": ["john@company.com"]}]
+  }
+)
+```
+
+## Minerva Enrichment
+
+Enrich with demographics, work history, education, contact info, addresses, financial signals:
+
+```mcp
+agentcash.fetch(
+  url="https://stableenrich.dev/api/minerva/enrich",
+  method="POST",
+  body={
+    "records": [{"record_id": "user_001", "linkedin_url": "https://www.linkedin.com/in/johndoe"}],
+    "return_fields": ["full_name", "personal_emails", "phones", "work_experience"]
+  }
+)
+```
+
+Lookup modes: by `minerva_pid` (fastest), `linkedin_url` in each record, or name/email/phone.
 
 ## Minerva Email Validation
-
-Check if emails exist in the Minerva database:
 
 ```mcp
 agentcash.fetch(
   url="https://stableenrich.dev/api/minerva/validate-emails",
   method="POST",
+  body={"records": ["john@company.com", "jane@example.com"]}
+)
+```
+
+## Contact Recovery (Clado)
+
+Find missing email or phone from a LinkedIn URL:
+
+```mcp
+agentcash.fetch(
+  url="https://stableenrich.dev/api/clado/contacts-enrich",
+  method="POST",
   body={
-    "records": ["john@company.com", "jane@example.com"]
+    "linkedin_url": "https://www.linkedin.com/in/johndoe",
+    "email_enrichment": true,
+    "phone_enrichment": true
   }
 )
 ```
 
-**Returns**: Validation status and last-seen timestamps. Use before resolve/enrich to pre-screen lists.
+## Parallel Calls
+
+When enriching multiple independent records, make parallel `fetch` calls — there are no bulk enrich endpoints:
+
+```mcp
+agentcash.fetch(url="https://stableenrich.dev/api/pdl/people-enrich", body={"email": "a@co.com"})
+agentcash.fetch(url="https://stableenrich.dev/api/pdl/people-enrich", body={"email": "b@co.com"})
+```
 
 ## Cost Optimization
 
-### Field Filtering
-
-Reduce costs by excluding unneeded fields:
-
-```
-body={
-  "email": "john@company.com",
-  "excludeFields": ["employment_history", "photos", "phone_numbers"]
-}
-```
-
-Common fields to exclude:
-- `employment_history` - Past jobs (often large)
-- `photos` - Profile images
-- `phone_numbers` - If you only need email
-- `social_profiles` - If you don't need social links
-
 ### Search Before Enrich
 
-Use search endpoints ($0.02) to find the right records before enriching ($0.0495):
+1. Search: `fullenrich/people-search` ($0.14 if results) — find candidates
+2. Enrich: `pdl/people-enrich` ($0.28 if match) — get email and career history
+3. Verify: `hunter/email-verifier` ($0.03) — confirm deliverability
 
-1. Search for candidates: `https://stableenrich.dev/api/apollo/people-search`
-2. Review results, pick the right match
-3. Enrich only the matches you need
+### Field Filtering
 
-## Parallel Calls
-
-When enriching multiple independent records, make calls in parallel:
-
-```mcp
-# These can run simultaneously since they're independent
-agentcash.fetch(url=".../people-enrich", body={"email": "a@co.com"})
-agentcash.fetch(url=".../people-enrich", body={"email": "b@co.com"})
-```
+FullEnrich people-search supports `excludeFields` to trim response size (e.g. `["educations", "skills", "languages"]`).
 
 ## Email Verification (Hunter)
-
-Verify if an email address is deliverable before sending outreach:
 
 ```mcp
 agentcash.fetch(
   url="https://stableenrich.dev/api/hunter/email-verifier",
   method="POST",
-  body={
-    "email": "john@stripe.com"
-  }
+  body={"email": "john@stripe.com"}
 )
 ```
 
-**Returns**: Deliverability status, MX record validation, SMTP verification, confidence score, and flags for catch-all, disposable, or role-based addresses.
-
-| Status | Meaning | Action |
-|--------|---------|--------|
-| `deliverable` | Email exists and accepts mail | Safe to send |
-| `undeliverable` | Email doesn't exist or rejects mail | Do not send |
-| `risky` | Catch-all domain or temporary issues | Send with caution |
-| `unknown` | Could not determine status | Try again later |
-
-**Tip:** Combine with people-enrich to find and verify contacts in one pipeline:
-1. Search: `people-search` ($0.02) -> find candidates
-2. Enrich: `people-enrich` ($0.0495) -> get email
-3. Verify: `hunter/email-verifier` ($0.03) -> confirm deliverability
-
-## Influencer Enrichment
-
-Enrich social media influencer/creator profiles across Instagram, TikTok, YouTube, and Facebook.
-
-### Find Profiles by Email
-
-```mcp
-agentcash.fetch(
-  url="https://stableenrich.dev/api/influencer/enrich-by-email",
-  method="POST",
-  body={
-    "email": "creator@example.com",
-    "platform": "instagram",
-    "enrichment_mode": "enhanced"
-  }
-)
-```
-
-**Parameters:**
-- `email` — the creator's email address (required)
-- `platform` — `"instagram"`, `"tiktok"`, `"youtube"`, `"twitter"`, `"facebook"` (required)
-- `enrichment_mode` — `"enhanced"` for full data (recommended)
-
-**Returns**: Social media profiles, follower counts, engagement metrics, audience demographics, contact info, content categories.
-
-### Enrich by Social Handle
-
-```mcp
-agentcash.fetch(
-  url="https://stableenrich.dev/api/influencer/enrich-by-social",
-  method="POST",
-  body={
-    "platform": "instagram",
-    "username": "creator_handle",
-    "enrichment_mode": "enhanced",
-    "email_required": "must_have"
-  }
-)
-```
-
-**Parameters:**
-- `platform` — `"instagram"`, `"tiktok"`, `"youtube"`, `"twitter"`, `"facebook"` (required)
-- `username` — handle on that platform (required)
-- `enrichment_mode` — `"enhanced"` for full data (recommended)
-- `email_required` — `"must_have"` to only return profiles with email
-
-**Returns**: Full profile with engagement metrics, contact info (email, phone), audience demographics, brand affinity, cross-platform links.
-
-### When to Use Which Provider
-
-- **Apollo/Clado** — B2B professional data (job titles, company, employment history)
-- **Minerva** — Consumer profiles (demographics, income/wealth estimates, address history, life events, personal contact info)
-- **Influencer** — Social media creators (followers, engagement, audience data)
+| Status          | Meaning                              | Action            |
+| --------------- | ------------------------------------ | ----------------- |
+| `deliverable`   | Email exists and accepts mail        | Safe to send      |
+| `undeliverable` | Email doesn't exist or rejects mail  | Do not send       |
+| `risky`         | Catch-all domain or temporary issues | Send with caution |
+| `unknown`       | Could not determine status           | Try again later   |
 
 ## Handling missing data
 
-If any query fails to return the data you are looking for, revisit the list of available APIs.
+If a query returns empty or incomplete data:
 
-Oftentimes, if Apollo is missing data, Clado or Minerva will have it, and vice versa. For consumer profiles (demographics, addresses, financial signals), try Minerva. For social media creators, try the influencer endpoints. For email deliverability, use Hunter.
+1. Re-run `discover_api_endpoints` and try an alternate provider (PDL vs Minerva vs Clado contacts)
+2. Verify company domain with `companyenrich/org-enrich` or `fullenrich/company-search` before people searches
+3. Fall back to Exa web search on stableenrich.dev for LinkedIn URLs or domains, then retry enrich with discovered identifiers
 
-If those still fail, use built-in WebSearch and WebFetch tools to find additional information like a company domain name or LinkedIn URL, and then use that data to make more targeted queries.
+For social media creator data, use **stablesocial.dev** instead of stableenrich.dev.

--- a/mcp/skills/data-enrichment/rules/getting-started.md
+++ b/mcp/skills/data-enrichment/rules/getting-started.md
@@ -31,14 +31,13 @@
 
 | Endpoint | Price |
 |----------|-------|
-| people-enrich | $0.0495 |
-| org-enrich | $0.0495 |
-| people-search | $0.02 |
-| org-search | $0.02 |
-| contacts-enrich | $0.20 |
-| email-verifier (Hunter) | $0.03 |
-| influencer enrich-by-email | $0.40 |
-| influencer enrich-by-social | $0.40 |
+| fullenrich/people-search | $0.14 (if results) |
+| fullenrich/company-search | $0.14 (if results) |
+| pdl/people-enrich | $0.28 (if match) |
+| companyenrich/org-enrich | $0.06 |
+| companyenrich/properties-enrich | $0.06 |
+| clado/contacts-enrich | $0.20 |
+| hunter/email-verifier | $0.03 |
 | minerva/resolve | $0.02 |
 | minerva/enrich | $0.05 |
 | minerva/validate-emails | $0.01 |

--- a/mcp/skills/people-property/SKILL.md
+++ b/mcp/skills/people-property/SKILL.md
@@ -198,7 +198,7 @@ At $0.44 per call, Whitepages is the most expensive endpoint in the x402 suite.
 **Tips to reduce costs:**
 - Provide as much info as possible for accurate first-try results
 - Use free sources first (LinkedIn, company websites)
-- Use apollo, clado, firecrawl, WebSearch, WebFetch, to get data that will make the queries more accurate
+- Use FullEnrich, PDL, Clado, firecrawl, WebSearch, WebFetch to get data that will make the queries more accurate
 - Only use for essential lookups
 
 ## Limitations

--- a/mcp/skills/people-property/rules/privacy.md
+++ b/mcp/skills/people-property/rules/privacy.md
@@ -55,7 +55,7 @@ This is sensitive personal information. Handle appropriately:
 | Need | Better Alternative |
 |------|-------------------|
 | Professional contact | LinkedIn, company website |
-| Business info | Apollo org-enrich |
+| Business info | CompanyEnrich org-enrich |
 | Email verification | Clado contacts-enrich |
 | General background | Public social profiles |
 

--- a/plugin/skills/agentcash/SKILL.md
+++ b/plugin/skills/agentcash/SKILL.md
@@ -9,7 +9,7 @@ description: |
   TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
 homepage: https://agentcash.dev
 metadata:
-  version: 2.2
+  version: 3.0
 ---
 
 # AgentCash — Paid API Access
@@ -73,7 +73,7 @@ Returns all endpoints, pricing, and usage instructions. **Read the `instructions
 ### 3. Check schema (optional)
 
 ```mcp
-agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/apollo/people-search")
+agentcash.check_endpoint_schema(url="https://stableenrich.dev/api/fullenrich/people-search")
 ```
 
 Returns full request/response JSON schemas and pricing for a specific endpoint.
@@ -82,9 +82,12 @@ Returns full request/response JSON schemas and pricing for a specific endpoint.
 
 ```mcp
 agentcash.fetch(
-  url="https://stableenrich.dev/api/apollo/people-search",
+  url="https://stableenrich.dev/api/fullenrich/people-search",
   method="POST",
-  body={"person_titles": ["CEO"], "person_locations": ["San Francisco"]}
+  body={
+    "current_company_domains": [{"value": "stripe.com"}],
+    "current_position_seniority_level": [{"value": "VP"}]
+  }
 )
 ```
 
@@ -95,7 +98,7 @@ Payment is automatic: sends request, gets 402 challenge, signs USDC payment, ret
 
 | Origin | Service | What it does |
 |---|---|---|
-| `https://stableenrich.dev` | StableEnrich | Research APIs: Apollo (people/org), Exa (web search), Firecrawl (scraping), Google Maps, Clado (LinkedIn), Serper (news/shopping), WhitePages, Reddit, Hunter (email verification), Influencer enrichment |
+| `https://stableenrich.dev` | StableEnrich | FullEnrich / CompanyEnrich / PDL people & company search, Minerva, Exa (web search), Firecrawl (scraping), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Reddit, Hunter (email verification) |
 | `https://stableupload.dev` | StableUpload | Pay-per-upload file hosting. 10MB/$0.02, 100MB/$0.20, 1GB/$2.00. 6-month TTL |
 | `https://stablestudio.dev` | StableStudio | AI image/video generation: GPT Image, Flux, Nano Banana, Sora, Veo, Seedance, Wan |
 | `https://stablesocial.dev` | StableSocial | Social media data: TikTok, Instagram, Facebook, Reddit, LinkedIn. $0.06/call, async two-step |

--- a/plugin/skills/agentcash/SKILL.md
+++ b/plugin/skills/agentcash/SKILL.md
@@ -5,7 +5,7 @@ description: |
   If the task matches a SERVICES origin below, SKIP search and go straight to discover → fetch.
   Only search when NO listed origin fits.
 
-  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit, LinkedIn), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation).
+  SERVICES: stableenrich (people/company, web search, scraping, Maps, LinkedIn, email verify, news), stablesocial (TikTok, Instagram, Facebook, Reddit), stablestudio (AI image/video), stableupload (file/site hosting), stableemail (email, inboxes, subdomains), stablephone (AI calls, phone numbers), stablejobs (jobs), stabletravel (travel), stablebrowser (browser automation).
   TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
 homepage: https://agentcash.dev
 metadata:
@@ -101,7 +101,7 @@ Payment is automatic: sends request, gets 402 challenge, signs USDC payment, ret
 | `https://stableenrich.dev` | StableEnrich | FullEnrich / CompanyEnrich / PDL people & company search, Minerva, Exa (web search), Firecrawl (scraping), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Reddit, Hunter (email verification) |
 | `https://stableupload.dev` | StableUpload | Pay-per-upload file hosting. 10MB/$0.02, 100MB/$0.20, 1GB/$2.00. 6-month TTL |
 | `https://stablestudio.dev` | StableStudio | AI image/video generation: GPT Image, Flux, Nano Banana, Sora, Veo, Seedance, Wan |
-| `https://stablesocial.dev` | StableSocial | Social media data: TikTok, Instagram, Facebook, Reddit, LinkedIn. $0.06/call, async two-step |
+| `https://stablesocial.dev` | StableSocial | Social media data: TikTok, Instagram, Facebook, Reddit. $0.06/call, async two-step |
 | `https://stableemail.dev` | StableEmail | Send emails ($0.02), forwarding inboxes ($1/mo), custom subdomains ($5) |
 | `https://stablephone.dev` | StablePhone | AI phone calls ($0.54), phone numbers ($20), top-ups ($15) |
 | `https://stablejobs.dev` | StableJobs | Job search via Coresignal |

--- a/skills/agentcash/SKILL.md
+++ b/skills/agentcash/SKILL.md
@@ -9,7 +9,7 @@ description: |
   TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
 homepage: https://agentcash.dev
 metadata:
-  version: 3.0
+  version: 3
 ---
 
 # AgentCash — Paid API Access

--- a/skills/agentcash/SKILL.md
+++ b/skills/agentcash/SKILL.md
@@ -9,7 +9,7 @@ description: |
   TRIGGERS: research, enrich, scrape, search the web, generate image, video, social media, send email, phone call, travel, jobs, find contact, find API, x402, mpp, agentcash
 homepage: https://agentcash.dev
 metadata:
-  version: 2.2
+  version: 3.0
 ---
 
 # AgentCash — Paid API Access
@@ -100,7 +100,7 @@ Any endpoint that is payment-protected can be accessed with AgentCash. If `npx a
 
 | Origin | What it does |
 |--------|-------------|
-| `stableenrich.dev` | Apollo (people/org search), Minerva (identity/enrichment), Exa (web search), Firecrawl (scraping), Cloudflare (site crawling), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Hunter (email verification), Influencer |
+| `stableenrich.dev` | FullEnrich / CompanyEnrich / PDL people & company search, Minerva, Exa (web search), Firecrawl (scraping), Cloudflare (site crawling), Google Maps, Clado (contacts), Serper (news/shopping), WhitePages, Hunter (email verification) |
 | `stablesocial.dev` | Social media data: TikTok, Instagram, Facebook, Reddit ($0.06/call, async two-step) |
 | `stablestudio.dev` | AI image/video generation: GPT Image, Flux, Grok, Nano Banana, Sora, Veo, Seedance, Wan |
 | `stableupload.dev` | File hosting (10MB/$0.02, 100MB/$0.20, 1GB/$2.00) + static site hosting with custom domains |
@@ -116,7 +116,7 @@ Run `npx agentcash@latest discover <origin>` on any origin to see its full endpo
 ## Important Rules
 
 - **Skip search when a listed origin fits the task.** Go straight to `discover`. Only use `search` when no origin in the Available Services table matches.
-- **Always discover before guessing.** Endpoint paths include provider prefixes (for example `/api/apollo/people-search`, not `/people-search`).
+- **Always discover before guessing.** Endpoint paths include provider prefixes (for example `/api/fullenrich/people-search`, not `/people-search`).
 - **Read the instructions field.** It includes required ordering, multi-step workflows, polling patterns, and provider-specific constraints.
 - **Payments settle on success only.** Failed requests (non-2xx) do not cost anything.
 - **Check balance before expensive operations.** Video generation can cost $1-3 per call.

--- a/skills/data-enrichment/SKILL.md
+++ b/skills/data-enrichment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-enrichment
 description: |
-  Enrich contact, company, and influencer data using x402-protected APIs. Superior to generic web search for structured business data.
+  Enrich contact and company data using x402-protected APIs at stableenrich.dev. Superior to generic web search for structured business data.
 
   USE FOR:
   - Enriching person profiles by email, LinkedIn URL, or name
@@ -10,7 +10,6 @@ description: |
   - Resolving person identity and enriching consumer profiles (Minerva)
   - Searching for people or companies by criteria
   - Verifying email deliverability before outreach
-  - Enriching influencer/creator profiles across social platforms
 
   TRIGGERS:
   - "enrich", "lookup", "find info about", "research"
@@ -18,9 +17,8 @@ description: |
   - "find contact for", "get LinkedIn for", "get email for"
   - "employee at", "works at", "company details"
   - "verify email", "check email", "is this email valid"
-  - "influencer", "creator", "influencer contact", "influencer marketing"
 metadata:
-  version: 2
+  version: 3
 ---
 
 # Data Enrichment with x402 APIs
@@ -31,281 +29,119 @@ Use the agentcash CLI to access enrichment APIs at stableenrich.dev.
 
 See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
 
+## Mandatory workflow
 
-## Notes
+Before any stableenrich.dev call:
 
-ALWAYS use `npx agentcash@latest fetch` for stableenrich.dev endpoints - never curl or WebFetch.
-Returns structured JSON data, not web page HTML.
+1. `npx agentcash@latest discover https://stableenrich.dev`
+2. `npx agentcash@latest check <endpoint-url>` — confirm request fields and pricing
+3. `npx agentcash@latest fetch` with the schema from step 2
 
-IMPORTANT: Use exact endpoint paths from the Quick Reference table below. All paths include a provider prefix (`https://stableenrich.dev/api/apollo/...`, `https://stableenrich.dev/api/clado/...`, etc.).
+ALWAYS use `npx agentcash@latest fetch` for stableenrich.dev endpoints — never curl or WebFetch.
+
+**Never guess field names.** FullEnrich people-search uses `current_company_domains` and `current_position_seniority_level` — not `company_domain`, `person_titles`, `titles`, or `seniority`. Response fields like `full_name`, `seniority`, and `domain` are output-only.
 
 ## Quick Reference
 
 | Task | Endpoint | Price | Best For |
 |------|----------|-------|----------|
-| Enrich person | `https://stableenrich.dev/api/apollo/people-enrich` | $0.0495 | Email/LinkedIn -> full profile |
-| Enrich company | `https://stableenrich.dev/api/apollo/org-enrich` | $0.0495 | Domain -> company data |
-| Search people | `https://stableenrich.dev/api/apollo/people-search` | $0.02 | Find people by criteria |
-| Search companies | `https://stableenrich.dev/api/apollo/org-search` | $0.02 | Find companies by criteria |
+| Search people | `https://stableenrich.dev/api/fullenrich/people-search` | $0.14 if results | Find people by domain/seniority |
+| Search companies | `https://stableenrich.dev/api/fullenrich/company-search` | $0.14 if results | Find companies by criteria |
+| Enrich person | `https://stableenrich.dev/api/pdl/people-enrich` | $0.28 if match | LinkedIn URL/email -> full profile |
+| Enrich person (alt) | `https://stableenrich.dev/api/minerva/enrich` | $0.05 | Demographics, work history |
+| Enrich company | `https://stableenrich.dev/api/companyenrich/org-enrich` | $0.06 | Domain -> company data |
+| Company by name/URL | `https://stableenrich.dev/api/companyenrich/properties-enrich` | $0.06 | When domain unknown |
 | Contact recovery | `https://stableenrich.dev/api/clado/contacts-enrich` | $0.20 | Find missing email/phone |
 | Verify email | `https://stableenrich.dev/api/hunter/email-verifier` | $0.03 | Check deliverability |
-| Influencer by email | `https://stableenrich.dev/api/influencer/enrich-by-email` | $0.40 | Email -> social profiles |
-| Influencer by social | `https://stableenrich.dev/api/influencer/enrich-by-social` | $0.40 | Handle -> creator data |
 | Minerva resolve | `https://stableenrich.dev/api/minerva/resolve` | $0.02 | Person -> Minerva PID + LinkedIn |
-| Minerva enrich | `https://stableenrich.dev/api/minerva/enrich` | $0.05 | Consumer demographics + contact |
 | Minerva email check | `https://stableenrich.dev/api/minerva/validate-emails` | $0.01 | Check emails in Minerva DB |
 
-## Workflows
+For social media creators, use **stablesocial.dev** — influencer endpoints are not on stableenrich.dev.
 
-### Standard Enrichment
+## Person Enrichment (PDL)
 
-- [ ] (Optional) Check balance: `npx agentcash@latest balance`
-- [ ] Use `npx agentcash@latest discover https://stableenrich.dev` to list all endpoints
-- [ ] Use `npx agentcash@latest check <endpoint-url>` to see expected parameters and pricing
-- [ ] Call endpoint with `npx agentcash@latest fetch`
-- [ ] Parse and present results
+Prefer `profile` (LinkedIn URL) or `email`:
 
 ```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/people-enrich -m POST -b '{"email": "user@company.com"}'
+npx agentcash@latest fetch https://stableenrich.dev/api/pdl/people-enrich -m POST -b '{"profile":"https://www.linkedin.com/in/johndoe"}'
 ```
 
-## Person Enrichment
+```bash
+npx agentcash@latest fetch https://stableenrich.dev/api/pdl/people-enrich -m POST -b '{"email":"john@company.com"}'
+```
 
-Enrich a person using any available identifier:
+Valid inputs: `email`, `profile`, or `first_name` + `last_name` + (`company_name` OR `company_domain`). No match: HTTP 200, `data: null` — not billed.
+
+## Company Enrichment (CompanyEnrich)
 
 ```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/people-enrich -m POST -b '{
-  "email": "john@company.com",
-  "first_name": "John",
-  "last_name": "Doe",
-  "organization_name": "Acme Inc",
-  "domain": "company.com",
-  "linkedin_url": "https://linkedin.com/in/johndoe"
+npx agentcash@latest fetch https://stableenrich.dev/api/companyenrich/org-enrich -m POST -b '{"domain":"stripe.com"}'
+```
+
+## People Search (FullEnrich)
+
+Start with domain + seniority:
+
+```bash
+npx agentcash@latest fetch https://stableenrich.dev/api/fullenrich/people-search -m POST -b '{
+  "current_company_domains": [{"value": "stripe.com"}],
+  "current_position_seniority_level": [{"value": "VP"}]
 }'
 ```
 
-**Input options** (provide any combination):
-- `email` - Email address (most reliable)
-- `linkedin_url` - LinkedIn profile URL
-- `first_name` + `last_name` - Name (works better with domain/org)
-- `organization_name` or `domain` - Helps match the right person
+**Not valid**: `offset` alone, `company_domain`, `titles`, `seniority`, `limit`, Apollo `person_titles` / `person_seniorities`.
 
-**Returns**: Name, title, company, employment history, location, social profiles, phone numbers.
-
-## Company Enrichment
-
-Enrich a company by domain:
+## Company Search (FullEnrich)
 
 ```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/org-enrich -m POST -b '{"domain": "stripe.com"}'
-```
-
-**Returns**: Company name, industry, employee count, revenue estimates, funding info, technologies used, social links.
-
-## People Search
-
-Search for people matching criteria:
-
-```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/people-search -m POST -b '{
-  "q_keywords": "software engineer",
-  "person_titles": ["CTO", "VP Engineering"],
-  "organization_domains": ["google.com", "meta.com"],
-  "person_locations": ["San Francisco, CA"]
-}'
-```
-
-**Search filters**:
-- `q_keywords` - Keywords to search
-- `person_titles` - Job title filters
-- `organization_domains` - Company domains
-- `person_locations` - Location filters
-- `person_seniorities` - Seniority levels
-
-## Company Search
-
-Search for companies matching criteria:
-
-```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/apollo/org-search -m POST -b '{
-  "q_keywords": "fintech",
-  "organization_locations": ["New York, NY"],
-  "organization_num_employees_ranges": ["51-200", "201-500"]
+npx agentcash@latest fetch https://stableenrich.dev/api/fullenrich/company-search -m POST -b '{
+  "domains": [{"value": "anthropic.com", "exact_match": true}]
 }'
 ```
 
 ## Contact Recovery (Clado)
 
-Enrich contact info from LinkedIn URL, email, or phone. Provide exactly one of `linkedin_url`, `email`, or `phone`:
-
 ```bash
 npx agentcash@latest fetch https://stableenrich.dev/api/clado/contacts-enrich -m POST -b '{
-  "linkedin_url": "https://linkedin.com/in/johndoe"
+  "linkedin_url": "https://www.linkedin.com/in/johndoe",
+  "email_enrichment": true,
+  "phone_enrichment": true
 }'
 ```
-
-**Returns**: Validated email addresses and phone numbers with confidence scores.
-
-**Note:** For LinkedIn profile data (experience, education, skills), use Minerva `/api/minerva/enrich` instead of Clado.
 
 ## Minerva Identity Resolution
 
-Resolve a person to a unique Minerva PID and LinkedIn URL:
-
 ```bash
 npx agentcash@latest fetch https://stableenrich.dev/api/minerva/resolve -m POST -b '{
-  "records": [
-    {
-      "record_id": "user_001",
-      "first_name": "John",
-      "last_name": "Smith",
-      "emails": ["john@company.com"]
-    }
-  ]
+  "records": [{"record_id": "user_001", "first_name": "John", "last_name": "Smith", "emails": ["john@company.com"]}]
 }'
 ```
 
-**Parameters:**
-- `records` array with: `record_id`, `first_name`, `last_name`, `emails`, `phones`, `linkedin_url`
-- Supports fuzzy match (name + contact) and reverse lookup (email/phone only, no name needed)
-- Use `match_condition_fields: ["linkedin_url"]` to only return matches with LinkedIn
-
 ## Minerva Enrichment
-
-Enrich with demographics, work history, education, contact info, addresses, financial signals:
-
-Three lookup modes: by Minerva PID (fastest), by LinkedIn URL, or by name/email/phone.
 
 ```bash
 npx agentcash@latest fetch https://stableenrich.dev/api/minerva/enrich -m POST -b '{
-  "records": [
-    {
-      "record_id": "user_001",
-      "first_name": "John",
-      "last_name": "Smith",
-      "emails": ["john@company.com"]
-    }
-  ],
+  "records": [{"record_id": "user_001", "linkedin_url": "https://www.linkedin.com/in/johndoe"}],
   "return_fields": ["full_name", "personal_emails", "phones", "work_experience"]
 }'
 ```
 
-**Parameters:**
-- `records` array with: `record_id` + one of `minerva_pid`, `linkedin_url`, or name/email/phone
-- `return_fields` array to limit response (e.g., `["full_name", "personal_emails", "phones", "work_experience"]`)
-- `match_condition_fields` to filter matches (e.g., `["email", "phone"]`)
-
-## Minerva Email Validation
-
-Check if emails exist in the Minerva database:
-
-```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/minerva/validate-emails -m POST -b '{
-  "records": ["john@company.com", "jane@example.com"]
-}'
-```
-
-**Returns**: Validation status and last-seen timestamps. Use before resolve/enrich to pre-screen lists.
-
 ## Cost Optimization
 
-### Field Filtering
+Search before enrich: `fullenrich/people-search` ($0.14 if results) -> `pdl/people-enrich` ($0.28 if match) -> `hunter/email-verifier` ($0.03).
 
-Reduce costs by excluding unneeded fields:
-
-```json
-{
-  "email": "john@company.com",
-  "excludeFields": ["employment_history", "photos", "phone_numbers"]
-}
-```
-
-Common fields to exclude:
-- `employment_history` - Past jobs (often large)
-- `photos` - Profile images
-- `phone_numbers` - If you only need email
-- `social_profiles` - If you don't need social links
-
-### Search Before Enrich
-
-Use search endpoints ($0.02) to find the right records before enriching ($0.0495):
-
-1. Search for candidates: `https://stableenrich.dev/api/apollo/people-search`
-2. Review results, pick the right match
-3. Enrich only the matches you need
+For multiple records, use parallel `fetch` calls — there are no bulk enrich endpoints.
 
 ## Email Verification (Hunter)
 
-Verify if an email address is deliverable before sending outreach:
-
 ```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/hunter/email-verifier -m POST -b '{"email": "john@stripe.com"}'
+npx agentcash@latest fetch https://stableenrich.dev/api/hunter/email-verifier -m POST -b '{"email":"john@stripe.com"}'
 ```
-
-**Returns**: Deliverability status, MX record validation, SMTP verification, confidence score, and flags for catch-all, disposable, or role-based addresses.
-
-| Status | Meaning | Action |
-|--------|---------|--------|
-| `deliverable` | Email exists and accepts mail | Safe to send |
-| `undeliverable` | Email doesn't exist or rejects mail | Do not send |
-| `risky` | Catch-all domain or temporary issues | Send with caution |
-| `unknown` | Could not determine status | Try again later |
-
-**Tip:** Combine with people-enrich to find and verify contacts in one pipeline:
-1. Search: `people-search` ($0.02) -> find candidates
-2. Enrich: `people-enrich` ($0.0495) -> get email
-3. Verify: `hunter/email-verifier` ($0.03) -> confirm deliverability
-
-## Influencer Enrichment
-
-Enrich social media influencer/creator profiles across Instagram, TikTok, YouTube, and Facebook.
-
-### Find Profiles by Email
-
-```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/influencer/enrich-by-email -m POST -b '{
-  "email": "creator@example.com",
-  "platform": "instagram",
-  "enrichment_mode": "enhanced"
-}'
-```
-
-**Parameters:**
-- `email` — the creator's email address (required)
-- `platform` — `"instagram"`, `"tiktok"`, `"youtube"`, `"twitter"`, `"facebook"` (required)
-- `enrichment_mode` — `"enhanced"` for full data (recommended)
-
-**Returns**: Social media profiles, follower counts, engagement metrics, audience demographics, contact info, content categories.
-
-### Enrich by Social Handle
-
-```bash
-npx agentcash@latest fetch https://stableenrich.dev/api/influencer/enrich-by-social -m POST -b '{
-  "platform": "instagram",
-  "username": "creator_handle",
-  "enrichment_mode": "enhanced",
-  "email_required": "must_have"
-}'
-```
-
-**Parameters:**
-- `platform` — `"instagram"`, `"tiktok"`, `"youtube"`, `"twitter"`, `"facebook"` (required)
-- `username` — handle on that platform (required)
-- `enrichment_mode` — `"enhanced"` for full data (recommended)
-- `email_required` — `"must_have"` to only return profiles with email
-
-**Returns**: Full profile with engagement metrics, contact info (email, phone), audience demographics, brand affinity, cross-platform links.
-
-### When to Use Which Provider
-
-- **Apollo/Clado** — B2B professional data (job titles, company, employment history)
-- **Minerva** — Consumer profiles (demographics, income/wealth estimates, address history, life events, personal contact info)
-- **Influencer** — Social media creators (followers, engagement, audience data)
 
 ## Handling missing data
 
-If any query fails to return the data you are looking for, revisit the list of available APIs.
+1. Re-run `discover` and try PDL vs Minerva vs Clado contacts
+2. Verify company domain with `companyenrich/org-enrich` before people searches
+3. Use Exa on stableenrich.dev to find LinkedIn URLs, then retry enrich
 
-Oftentimes, if Apollo is missing data, Clado or Minerva will have it, and vice versa. For consumer profiles (demographics, addresses, financial signals), try Minerva. For social media creators, try the influencer endpoints. For email deliverability, use Hunter.
-
-If those still fail, use built-in WebSearch and WebFetch tools to find additional information like a company domain name or LinkedIn URL, and then use that data to make more targeted queries.
+For social media creators, use **stablesocial.dev**.

--- a/skills/data-enrichment/rules/getting-started.md
+++ b/skills/data-enrichment/rules/getting-started.md
@@ -31,14 +31,13 @@
 
 | Endpoint | Price |
 |----------|-------|
-| people-enrich | $0.0495 |
-| org-enrich | $0.0495 |
-| people-search | $0.02 |
-| org-search | $0.02 |
-| contacts-enrich | $0.20 |
-| email-verifier (Hunter) | $0.03 |
-| influencer enrich-by-email | $0.40 |
-| influencer enrich-by-social | $0.40 |
+| fullenrich/people-search | $0.14 (if results) |
+| fullenrich/company-search | $0.14 (if results) |
+| pdl/people-enrich | $0.28 (if match) |
+| companyenrich/org-enrich | $0.06 |
+| companyenrich/properties-enrich | $0.06 |
+| clado/contacts-enrich | $0.20 |
+| hunter/email-verifier | $0.03 |
 | minerva/resolve | $0.02 |
 | minerva/enrich | $0.05 |
 | minerva/validate-emails | $0.01 |

--- a/skills/people-property/SKILL.md
+++ b/skills/people-property/SKILL.md
@@ -173,7 +173,7 @@ At $0.44 per call, Whitepages is the most expensive endpoint in the x402 suite.
 **Tips to reduce costs:**
 - Provide as much info as possible for accurate first-try results
 - Use free sources first (LinkedIn, company websites)
-- Use apollo, clado, firecrawl, WebSearch, WebFetch, to get data that will make the queries more accurate
+- Use FullEnrich, PDL, Clado, firecrawl, WebSearch, WebFetch to get data that will make the queries more accurate
 - Only use for essential lookups
 
 ## Limitations

--- a/skills/people-property/rules/privacy.md
+++ b/skills/people-property/rules/privacy.md
@@ -55,7 +55,7 @@ This is sensitive personal information. Handle appropriately:
 | Need | Better Alternative |
 |------|-------------------|
 | Professional contact | LinkedIn, company website |
-| Business info | Apollo org-enrich |
+| Business info | CompanyEnrich org-enrich |
 | Email verification | Clado contacts-enrich |
 | General background | Public social profiles |
 


### PR DESCRIPTION
## Summary
- Update `skills/agentcash`, `plugin/skills/agentcash`, and `mcp/skills/agentcash-wallet` to reference FullEnrich/PDL instead of removed Apollo routes.
- Rewrite `data-enrichment` skill (CLI + MCP copies) with current StableEnrich endpoints, mandatory discover/check workflow, and Minerva sections.
- Refresh README examples and people-property privacy references.

## Test plan
- [x] `rg apollo/people` returns no hits in repo
- [ ] Merge before agentcash `FIRST_PARTY_SKILLS.agentcash.version = 3` auto-refresh takes effect
- [ ] Pair with agentcash PR for full rollout


Made with [Cursor](https://cursor.com)