### PR TITLE
Remove unverified FullEnrich alias claims and sync data-enrichment copies

### DIFF
--- a/mcp/skills/data-enrichment/SKILL.md
+++ b/mcp/skills/data-enrichment/SKILL.md
@@ -24,7 +24,7 @@ description: |
 mcp:
   - agentcash
 metadata:
-  version: 3
+  version: 3.1
 ---
 
 # Data Enrichment with x402 APIs
@@ -130,7 +130,7 @@ agentcash.fetch(
 
 **Key filters**:
 
-- `current_company_domains` — company domain(s); aliases: `domains`, `company_domains`, `domain`
+- `current_company_domains` — company domain(s)
 - `current_position_seniority_level` — enum: `C-level`, `VP`, `Head`, `Director`, `Manager`, etc.
 - `current_position_titles` — exact title match (returns far fewer results)
 - `person_locations`, `person_professional_network_urls`, and 20+ other FullEnrich filters

--- a/mcp/skills/people-property/SKILL.md
+++ b/mcp/skills/people-property/SKILL.md
@@ -17,11 +17,11 @@ description: |
   IMPORTANT: These endpoints contain personal information. Use responsibly and only for legitimate purposes.
   See rules/privacy.md for guidance.
 
-  Use agentcash.fetch for Whitepages endpoints. Both endpoints are $0.44 per call.
+  Use agentcash.fetch for Whitepages endpoints. Both endpoints are $0.22 per call.
 mcp:
   - agentcash
 metadata:
-  version: 2
+  version: 2.1
 ---
 
 # People & Property Search with Whitepages
@@ -38,8 +38,8 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 
 | Task | Endpoint | Price | Description |
 |------|----------|-------|-------------|
-| Person search | `https://stableenrich.dev/api/whitepages/person-search` | $0.44 | Find people by name/location |
-| Property search | `https://stableenrich.dev/api/whitepages/property-search` | $0.44 | Property and owner info |
+| Person search | `https://stableenrich.dev/api/whitepages/person-search` | $0.22 | Find people by name/location |
+| Property search | `https://stableenrich.dev/api/whitepages/property-search` | $0.22 | Property and owner info |
 
 ## Person Search
 
@@ -187,13 +187,13 @@ agentcash.fetch(
 
 ## Cost Considerations
 
-At $0.44 per call, Whitepages is the most expensive endpoint in the x402 suite.
+At $0.22 per call, Whitepages is the most expensive endpoint in the x402 suite.
 
 | Scenario | Cost |
 |----------|------|
-| Single lookup | $0.44 |
-| Verify address + person | $0.88 |
-| Multiple candidates | $1.32+ |
+| Single lookup | $0.22 |
+| Verify address + person | $0.44 |
+| Multiple candidates | $0.66+ |
 
 **Tips to reduce costs:**
 - Provide as much info as possible for accurate first-try results

--- a/skills/data-enrichment/SKILL.md
+++ b/skills/data-enrichment/SKILL.md
@@ -18,7 +18,7 @@ description: |
   - "employee at", "works at", "company details"
   - "verify email", "check email", "is this email valid"
 metadata:
-  version: 3
+  version: 3.1
 ---
 
 # Data Enrichment with x402 APIs
@@ -80,7 +80,7 @@ npx agentcash@latest fetch https://stableenrich.dev/api/companyenrich/org-enrich
 
 ## People Search (FullEnrich)
 
-Start with domain + seniority:
+Start with **domain + seniority**; add `current_position_titles` only when you need exact title match.
 
 ```bash
 npx agentcash@latest fetch https://stableenrich.dev/api/fullenrich/people-search -m POST -b '{
@@ -89,7 +89,16 @@ npx agentcash@latest fetch https://stableenrich.dev/api/fullenrich/people-search
 }'
 ```
 
+**Key filters**:
+
+- `current_company_domains` — company domain(s)
+- `current_position_seniority_level` — enum: `C-level`, `VP`, `Head`, `Director`, `Manager`, etc.
+- `current_position_titles` — exact title match (returns far fewer results)
+- `person_locations`, `person_professional_network_urls`, and 20+ other FullEnrich filters
+
 **Not valid**: `offset` alone, `company_domain`, `titles`, `seniority`, `limit`, Apollo `person_titles` / `person_seniorities`.
+
+Returns up to 10 people per query. Empty `people` → not billed.
 
 ## Company Search (FullEnrich)
 
@@ -98,6 +107,8 @@ npx agentcash@latest fetch https://stableenrich.dev/api/fullenrich/company-searc
   "domains": [{"value": "anthropic.com", "exact_match": true}]
 }'
 ```
+
+Requires at least one search filter. Paginate via `search_after` from `metadata`.
 
 ## Contact Recovery (Clado)
 
@@ -126,11 +137,23 @@ npx agentcash@latest fetch https://stableenrich.dev/api/minerva/enrich -m POST -
 }'
 ```
 
+Lookup modes: by `minerva_pid` (fastest), `linkedin_url` in each record, or name/email/phone.
+
+## Minerva Email Validation
+
+```bash
+npx agentcash@latest fetch https://stableenrich.dev/api/minerva/validate-emails -m POST -b '{
+  "records": ["john@company.com", "jane@example.com"]
+}'
+```
+
 ## Cost Optimization
 
 Search before enrich: `fullenrich/people-search` ($0.14 if results) -> `pdl/people-enrich` ($0.28 if match) -> `hunter/email-verifier` ($0.03).
 
 For multiple records, use parallel `fetch` calls — there are no bulk enrich endpoints.
+
+FullEnrich people-search supports `excludeFields` to trim response size (e.g. `["educations", "skills", "languages"]`).
 
 ## Email Verification (Hunter)
 

--- a/skills/people-property/SKILL.md
+++ b/skills/people-property/SKILL.md
@@ -17,9 +17,9 @@ description: |
   IMPORTANT: These endpoints contain personal information. Use responsibly and only for legitimate purposes.
   See rules/privacy.md for guidance.
 
-  Use `npx agentcash@latest fetch` for Whitepages endpoints. Both endpoints are $0.44 per call.
+  Use `npx agentcash@latest fetch` for Whitepages endpoints. Both endpoints are $0.22 per call.
 metadata:
-  version: 2
+  version: 2.1
 ---
 
 # People & Property Search with Whitepages
@@ -36,8 +36,8 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 
 | Task | Endpoint | Price | Description |
 |------|----------|-------|-------------|
-| Person search | `https://stableenrich.dev/api/whitepages/person-search` | $0.44 | Find people by name/location |
-| Property search | `https://stableenrich.dev/api/whitepages/property-search` | $0.44 | Property and owner info |
+| Person search | `https://stableenrich.dev/api/whitepages/person-search` | $0.22 | Find people by name/location |
+| Property search | `https://stableenrich.dev/api/whitepages/property-search` | $0.22 | Property and owner info |
 
 ## Person Search
 
@@ -162,13 +162,13 @@ npx agentcash@latest fetch https://stableenrich.dev/api/whitepages/person-search
 
 ## Cost Considerations
 
-At $0.44 per call, Whitepages is the most expensive endpoint in the x402 suite.
+At $0.22 per call, Whitepages is the most expensive endpoint in the x402 suite.
 
 | Scenario | Cost |
 |----------|------|
-| Single lookup | $0.44 |
-| Verify address + person | $0.88 |
-| Multiple candidates | $1.32+ |
+| Single lookup | $0.22 |
+| Verify address + person | $0.44 |
+| Multiple candidates | $0.66+ |
 
 **Tips to reduce costs:**
 - Provide as much info as possible for accurate first-try results


### PR DESCRIPTION
## Summary
- Remove the `current_company_domains` alias claim (`domains`, `company_domains`, `domain`) from the MCP data-enrichment skill — the live people-search schema declares no such aliases, and the claim contradicted the skill's own "Never guess field names" rule. An agent trusting it could send an ignored filter and pay $0.14 for unfiltered results.
- Sync the CLI data-enrichment copy with the MCP copy: key filters list, up-to-10-results / not-billed note, company-search filter requirement and `search_after` pagination, Minerva lookup modes and validate-emails example, `excludeFields` tip.
- Fix stale Whitepages pricing in people-property skills: both endpoints are $0.22 per call (was $0.44), with the cost scenario table updated to match.
- Bump versions: data-enrichment 3 -> 3.1, people-property 2 -> 2.1.

All endpoint fields and prices verified against the live stableenrich.dev OpenAPI spec.