### PR TITLE
feat(pulse-network): add skill for PulseNetwork vertical intelligence APIs (66 x402 origins)

### DIFF
--- a/mcp/skills/pulse-network/SKILL.md
+++ b/mcp/skills/pulse-network/SKILL.md
@@ -31,7 +31,7 @@ metadata:
 
 66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
-Catalog: https://mcp-pulsenetwork.vercel.app · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+Catalog: https://pulsenetwork.theaslangroupllc.com · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
 ## Setup
 

--- a/mcp/skills/pulse-network/SKILL.md
+++ b/mcp/skills/pulse-network/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: pulse-network
+description: |
+  Vertical intelligence APIs across 66 x402 origins (826 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
+
+  USE FOR:
+  - Sanctions/OFAC screening, EU VAT validation, GLEIF LEI lookups
+  - Pre-trade token safety scans (Solana memecoins, EVM tokens, multi-chain)
+  - SEC/EDGAR fundamentals, filing search, 13F due diligence
+  - Perp funding rates, arbitrage math, FX-premium signals (Hyperliquid, dYdX)
+  - Tax rates and VAT/GST for 195 countries; global visa/immigration checks
+  - FDIC bank-health checks, credit-card benefit coverage
+  - Real-time weather/air quality, earthquake checks, country risk
+  - Deep verticals: healthcare prices, clinical trials, grants, patents, real estate, transit, racing, esports — see rules/origins.md
+
+  TRIGGERS:
+  - "sanctions check", "OFAC", "screen this entity", "validate VAT", "LEI"
+  - "is this token safe", "memecoin check", "rug check", "scan token"
+  - "SEC filing", "10-K", "13F", "company fundamentals"
+  - "funding rate", "arbitrage", "stablecoin premium"
+  - "tax rate in", "VAT in", "visa requirements"
+  - "is my bank safe", "FDIC", "card benefit"
+  - "country risk", "travel safety", "air quality"
+
+  All origins share one pattern: `https://<vertical>.theaslangroupllc.com`. Use agentcash.discover_api_endpoints to enumerate any origin, and agentcash.fetch to call endpoints.
+metadata:
+  version: 1
+---
+
+# PulseNetwork — Vertical Intelligence APIs
+
+66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
+
+Catalog: https://www.pulsenetwork.dev · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference — flagship endpoints
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| OFAC sanctions screen (alias-aware, deterministic) | `https://compliancepulse.theaslangroupllc.com/api/screen/sanctions` | $0.02 |
+| EU VAT number validation (VIES, deterministic) | `https://compliancepulse.theaslangroupllc.com/api/validate/vat` | $0.01 |
+| Solana memecoin pre-trade scan (deterministic verdict) | `https://onchainpulse.theaslangroupllc.com/api/memecoin` | $0.015 |
+| EVM token pre-trade scan (multi-chain) | `https://onchainpulse.theaslangroupllc.com/api/evmtoken` | $0.015 |
+| SEC XBRL fundamentals — 8 quarters, deterministic | `https://filingspulse.theaslangroupllc.com/api/filings/quarterly` | $0.02 |
+| Perp funding-rate check (cross-venue normalized) | `https://cryptopulse.theaslangroupllc.com/api/funding-check` | $0.02 |
+| Stablecoin parallel-rate FX premium signal | `https://arbipulse.theaslangroupllc.com/api/fx-premium` | $0.02 |
+| FDIC bank-health check (Call Report primitive) | `https://wealthpulse.theaslangroupllc.com/api/wealth/bank-check` | $0.02 |
+| Country tax system overview (195 countries) | `https://taxpulse.theaslangroupllc.com/api/tax/country` | $0.10 |
+| Earthquake activity check (USGS, deterministic) | `https://riskpulse.theaslangroupllc.com/api/risk/quake-check` | $0.01 |
+| Real-time air quality + health risk | `https://climatepulse.theaslangroupllc.com/api/climate/air` | $0.05 |
+| Country risk assessment | `https://geopoliticalpulse.theaslangroupllc.com/api/geopolitical/country-risk` | $0.15 |
+| AI-visibility check of any website (verbatim evidence) | `https://marketpulse.theaslangroupllc.com/api/market/ai-visibility-check` | $0.50 |
+
+Full directory of all 66 origins grouped by category: [rules/origins.md](rules/origins.md).
+
+## Workflow
+
+1. **Pick an origin** from the task → category mapping in [rules/origins.md](rules/origins.md) (or the Quick Reference above).
+2. **Discover** its endpoints and prices:
+   ```mcp
+   agentcash.discover_api_endpoints("https://compliancepulse.theaslangroupllc.com")
+   ```
+3. **Check** a specific endpoint's schema and price before first use:
+   ```mcp
+   agentcash.check_endpoint_schema("https://compliancepulse.theaslangroupllc.com/api/screen/sanctions")
+   ```
+4. **Fetch** (most endpoints are GET with query params):
+   ```mcp
+   agentcash.fetch(url="https://compliancepulse.theaslangroupllc.com/api/screen/sanctions?name=ACME%20Trading%20Ltd")
+   ```
+
+## Examples
+
+Sanctions screen before a payment:
+
+```mcp
+agentcash.fetch(url="https://compliancepulse.theaslangroupllc.com/api/screen/sanctions?name=Example%20Corp")
+```
+
+Token safety scan before a trade:
+
+```mcp
+agentcash.fetch(url="https://onchainpulse.theaslangroupllc.com/api/memecoin?mint=<SOLANA_MINT_ADDRESS>")
+```
+
+Eight quarters of reported fundamentals for a ticker:
+
+```mcp
+agentcash.fetch(url="https://filingspulse.theaslangroupllc.com/api/filings/quarterly?company=NVDA")
+```
+
+Country tax overview:
+
+```mcp
+agentcash.fetch(url="https://taxpulse.theaslangroupllc.com/api/tax/country?country=Portugal")
+```
+
+## Notes
+
+- Unpaid requests return a standard x402 402 challenge (before body validation) with exact price and pay-to details.
+- Endpoints marked "deterministic" return primary-source data with no LLM synthesis — stable output for a given input, suitable for agent pipelines.
+- Upstream failures return 4xx/5xx without settling payment.
+- Questions: info@theaslangroupllc.com

--- a/mcp/skills/pulse-network/SKILL.md
+++ b/mcp/skills/pulse-network/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pulse-network
 description: |
-  Vertical intelligence APIs across 66 x402 origins (826 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
+  Vertical intelligence APIs across 67 x402 origins (827 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
 
   USE FOR:
   - Sanctions/OFAC screening, EU VAT validation, GLEIF LEI lookups
@@ -12,6 +12,7 @@ description: |
   - FDIC bank-health checks, credit-card benefit coverage
   - Real-time weather/air quality, earthquake checks, country risk
   - Deep verticals: healthcare prices, clinical trials, grants, patents, real estate, transit, racing, esports — see rules/origins.md
+  - Send real physical mail (USPS letters, certified mail with tracking) — an ACTION endpoint, not a lookup
 
   TRIGGERS:
   - "sanctions check", "OFAC", "screen this entity", "validate VAT", "LEI"
@@ -21,6 +22,7 @@ description: |
   - "tax rate in", "VAT in", "visa requirements"
   - "is my bank safe", "FDIC", "card benefit"
   - "country risk", "travel safety", "air quality"
+  - "send a letter", "mail this", "certified mail", "USPS tracking"
 
   All origins share one pattern: `https://<vertical>.theaslangroupllc.com`. Use agentcash.discover_api_endpoints to enumerate any origin, and agentcash.fetch to call endpoints.
 metadata:
@@ -29,7 +31,7 @@ metadata:
 
 # PulseNetwork — Vertical Intelligence APIs
 
-66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
+67 single-purpose x402 API origins (827 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
 Catalog: https://pulsenetwork.theaslangroupllc.com · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
@@ -54,8 +56,10 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 | Real-time air quality + health risk | `https://climatepulse.theaslangroupllc.com/api/climate/air` | $0.05 |
 | Country risk assessment | `https://geopoliticalpulse.theaslangroupllc.com/api/geopolitical/country-risk` | $0.15 |
 | AI-visibility check of any website (verbatim evidence) | `https://marketpulse.theaslangroupllc.com/api/market/ai-visibility-check` | $0.50 |
+| Send a real physical letter — USPS, first-class/certified/international (ACTION: prints & mails on payment) | `https://mailpulse.theaslangroupllc.com/api/letters` | $3–$14 |
+| Verify a mailing address before sending physical mail (USPS-backed) | `https://mailpulse.theaslangroupllc.com/api/verify-address` | $0.01 |
 
-Full directory of all 66 origins grouped by category: [rules/origins.md](rules/origins.md).
+Full directory of all 67 origins grouped by category: [rules/origins.md](rules/origins.md).
 
 ## Workflow
 

--- a/mcp/skills/pulse-network/SKILL.md
+++ b/mcp/skills/pulse-network/SKILL.md
@@ -31,7 +31,7 @@ metadata:
 
 66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
-Catalog: https://www.pulsenetwork.dev · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+Catalog: https://mcp-pulsenetwork.vercel.app · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
 ## Setup
 

--- a/mcp/skills/pulse-network/rules/getting-started.md
+++ b/mcp/skills/pulse-network/rules/getting-started.md
@@ -1,0 +1,25 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash MCP:**
+   ```bash
+   npx agentcash@latest install --client claude-code
+   ```
+
+2. **Check wallet:**
+```mcp
+   agentcash.get_balance()
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `agentcash.redeem_invite(code="YOUR_CODE")`
+   - Or call `agentcash.list_accounts()` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "MCP tool not found" | Run install command, restart Claude Code |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |

--- a/mcp/skills/pulse-network/rules/origins.md
+++ b/mcp/skills/pulse-network/rules/origins.md
@@ -1,0 +1,100 @@
+# PulseNetwork Origin Directory
+
+All origins follow `https://<name>.theaslangroupllc.com`. Every origin serves `/openapi.json` (with per-route `x-payment-info` pricing), `/.well-known/agent.json`, and `/llms.txt`. Discover any origin with `agentcash.discover_api_endpoints(<origin>)`.
+
+## Finance & Markets
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://alphapulse.theaslangroupllc.com` | 13 | $0.08–$0.5 | The due-diligence layer for traders and allocators, worldwide — check before you fund. Official SEC EDGAR 13F hedge-fund holdings fetched |
+| `https://arbipulse.theaslangroupllc.com` | 15 | $0.02–$0.75 | The arbitrage layer for every market — 18 endpoints finding the same thing at two prices. Beyond-finance lanes: prediction-market |
+| `https://cryptopulse.theaslangroupllc.com` | 24 | $0.02–$0.5 | Global cryptocurrency intelligence API. 10 endpoints: DeFi yield farming across Ethereum/Base/Arbitrum/Solana (DeFiLlama live TVL + APY), |
+| `https://onchainpulse.theaslangroupllc.com` | 15 | $0.015–$0.25 | Intelligence API for the onchain financial transition. Decodes legislation, tracks RWA tokenization, models sector scenarios, guides |
+| `https://filingspulse.theaslangroupllc.com` | 15 | $0.02–$0.25 | Global SEC/EDGAR and international filings intelligence API. AI-synthesized plain-language summaries of 10-K, 10-Q, 8-K, S-1/IPO filings. |
+| `https://wealthpulse.theaslangroupllc.com` | 18 | $0.02–$2 | Personal finance intelligence API. 14 endpoints grounded in live FRED rate data and official FDIC Call Report data — financial health, |
+| `https://venturepulse.theaslangroupllc.com` | 10 | $0.1–$0.2 | Startup funding intelligence API. VC round data, investor matching, pitch deck scoring, term sheet decoding, cap table modeling, global |
+| `https://econsignalpulse.theaslangroupllc.com` | 10 | $0.08–$0.25 | Alternative economic intelligence API covering 190+ countries. Combines World Bank Open Data, IMF Datamapper forecasts, satellite nighttime |
+| `https://prospectpulse.theaslangroupllc.com` | 10 | $0.1–$0.35 | Global mineral and resource exploration intelligence. USGS MRDS deposit inventory, geochemical anomaly analysis, satellite scene |
+
+## Compliance, Legal & Government
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://compliancepulse.theaslangroupllc.com` | 14 | $0.01–$1.5 | Global regulatory intelligence API. 13 endpoints. Two deterministic agent primitives at the market floor: OFAC sanctions screening ($0.02) |
+| `https://legalpulse.theaslangroupllc.com` | 12 | $0.08–$2 | The clearance layer before you sign, send, or sue — 12 endpoints for legal agents and the people they work for. Pre-signature contract |
+| `https://policypulse.theaslangroupllc.com` | 14 | $0.02–$0.2 | PolicyPulse — global legislative intelligence: US Congress, EU (EUR-Lex), UK Parliament, India, Brazil, Australia, and 50+ jurisdictions. |
+| `https://taxpulse.theaslangroupllc.com` | 15 | $0.1–$12 | Global tax intelligence API. AI-synthesized tax guidance for 195 countries: income tax rates, VAT/GST, corporate tax, capital gains, crypto |
+| `https://riskpulse.theaslangroupllc.com` | 11 | $0.01–$0.15 | Global risk intelligence API. AI-synthesized travel safety alerts, country risk profiles, sanctions screening, business risk analysis, |
+| `https://geopoliticalpulse.theaslangroupllc.com` | 10 | $0.15–$0.25 | Real-time geopolitical intelligence for investors, compliance teams, and AI agents. Political risk, conflict monitoring, sanctions, |
+| `https://govspendpulse.theaslangroupllc.com` | 9 | $0.08–$0.2 | Global government procurement intelligence API. 9 endpoints covering US federal contracts (USASpending.gov), active solicitations |
+| `https://truthpulse.theaslangroupllc.com` | 11 | $0.08–$0.2 | Primary-source intelligence for FOIA releases, declassified archives, court records, forensic evidence, UAP disclosures, and conspiracy |
+| `https://patentpulse.theaslangroupllc.com` | 11 | $0.05–$0.2 | PatentPulse — global IP intelligence: USPTO/EPO/WIPO/JPO/CNIPA patent search, FTO analysis, SEP licensing, trademark clearance, prior art, |
+| `https://immigrationpulse.theaslangroupllc.com` | 12 | $0.05–$0.2 | Global immigration intelligence API serving 281M+ migrants. 11 endpoints covering visa requirements, PR pathways, points calculators |
+| `https://tradepulse.theaslangroupllc.com` | 12 | $0.08–$0.2 | Global trade intelligence API. AI-synthesized tariff rates, HS code classification, FTA duty analysis, landed cost calculation, trade |
+| `https://esgpulse.theaslangroupllc.com` | 17 | $0.05–$0.25 | AI-powered ESG and sustainability intelligence: CSRD compliance roadmaps, EU Taxonomy alignment, supply chain due diligence, emissions |
+
+## Business, Careers & Funding
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://marketpulse.theaslangroupllc.com` | 12 | $0.08–$0.5 | The AI-visibility layer for businesses anywhere in the world — get found by the assistants doing the choosing. Live AI-visibility check |
+| `https://dealpulse.theaslangroupllc.com` | 13 | $0.05–$2 | Deal verification and intelligence API. deal-check verifies which offers are REAL at any store, first-party sources only with source URLs |
+| `https://findpulse.theaslangroupllc.com` | 13 | $0.05–$0.5 | Universal finder and discovery API — the research layer before the transaction, built for shopping and buyer agents. Pre-purchase |
+| `https://franchisepulse.theaslangroupllc.com` | 9 | $0.08–$0.2 | Global franchise intelligence API. AI-synthesized franchise discovery, FDD analysis, total cost modeling, SBA loan analysis, resale |
+| `https://careerpulse.theaslangroupllc.com` | 13 | $0.05–$2 | Global career intelligence API serving the world's 3.5 billion workers. 10 endpoints: salary benchmarking (any role + any country, sourced |
+| `https://talentpulse.theaslangroupllc.com` | 10 | $0.1–$0.25 | Global workforce intelligence API — salary benchmarks, remote compliance, EOR cost models, skills demand, work visas, talent market |
+| `https://grantpulse.theaslangroupllc.com` | 14 | $0.08–$2 | The funding-discovery layer for organisations anywhere — grounded in official sources fetched live: Grants.gov, the EU Funding & Tenders |
+| `https://scholarpulse.theaslangroupllc.com` | 13 | $0.08–$0.15 | Global scholarship and student finance intelligence. 13 endpoints covering scholarship search (190+ countries), international scholarship |
+| `https://edupulse.theaslangroupllc.com` | 19 | $0.05–$5 | Global education intelligence API — 18 endpoints for students, test-takers, homeschool families, and lifelong learners worldwide. Study |
+
+## Health, Home & Personal Finance
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://clearcarepulse.theaslangroupllc.com` | 10 | $0.05–$5 | Healthcare price transparency and cost navigation API. AI-synthesized procedure price search, cash-pay alternatives, hospital quality |
+| `https://clinicalintelpulse.theaslangroupllc.com` | 14 | $0.02–$0.35 | Pharmaceutical pipeline and clinical trial intelligence API. Synthesizes 400,000+ registered trials from ClinicalTrials.gov with FDA |
+| `https://herbapulse.theaslangroupllc.com` | 10 | $0.08–$0.25 | Global herbal medicine and botanical intelligence API. PubMed-grounded herb profiles, drug-herb interaction checker, traditional medicine |
+| `https://nutripulse.theaslangroupllc.com` | 15 | $0.02–$0.15 | Global nutrition intelligence API. PubMed-grounded supplement analysis, macro/micronutrient planning, food database lookups, |
+| `https://mindpulse.theaslangroupllc.com` | 11 | $0.08–$0.1 | Global mental health intelligence API. Evidence-based guidance on therapy platform matching, mental health assessment, burnout, psychiatric |
+| `https://longevitypulse.theaslangroupllc.com` | 11 | $0.1–$0.25 | Global longevity intelligence API — biomarker interpretation, supplement evidence, personalized protocols, clinical trials, Blue Zone |
+| `https://fitpulse.theaslangroupllc.com` | 10 | $0.08–$0.1 | Global fitness intelligence API. Evidence-based workout programming, nutrition science, supplement efficacy analysis, injury recovery |
+| `https://mealpulse.theaslangroupllc.com` | 10 | $0.05–$0.15 | Global meal planning and culinary intelligence API. AI-synthesized meal plans, recipe generation, dietary restriction guidance, grocery |
+| `https://petpulse.theaslangroupllc.com` | 12 | $0.08–$0.1 | Global pet health and care intelligence API. AI-synthesized veterinary symptom triage, breed selection guides, pet nutrition analysis, |
+| `https://parentpulse.theaslangroupllc.com` | 10 | $0.08–$0.12 | ParentPulse — child development and parenting intelligence: developmental milestones, nutrition guidance, pediatric health, sleep science, |
+| `https://seniorpulse.theaslangroupllc.com` | 14 | $0.08–$0.15 | Global elder care intelligence API. AI-synthesized Medicare/pension guidance, care facility evaluation, medication safety, benefits |
+| `https://vetpulse.theaslangroupllc.com` | 10 | $0.05–$0.2 | Global veterans benefits intelligence API. AI-synthesized guidance on disability compensation, Aid & Attendance-style pensions, |
+| `https://safepulse.theaslangroupllc.com` | 9 | $0.08–$0.12 | SafePulse — product safety intelligence: CPSC, FDA, USDA FSIS, NHTSA recalls; EU RAPEX; home safety scores; child/vehicle safety ratings; |
+| `https://insurepulse.theaslangroupllc.com` | 14 | $0.05–$2 | AI-synthesized insurance intelligence. Auto coverage analysis, life insurance needs calculator, homeowners gap finder, annual coverage |
+| `https://debtpulse.theaslangroupllc.com` | 21 | $0.05–$0.2 | Global debt elimination intelligence. All endpoints require x402 payment (USDC on Base mainnet) via the PAYMENT-SIGNATURE header. Supports |
+| `https://remittancepulse.theaslangroupllc.com` | 11 | $0.05–$2 | Global remittance intelligence API covering the $700B+ annual global remittance market. 9 endpoints: corridor analysis (200+ corridors), |
+| `https://homepulse.theaslangroupllc.com` | 10 | $0.08–$0.1 | Global home intelligence API. AI-synthesized home maintenance checklists, improvement ROI analysis, neighborhood research, smart home |
+| `https://buildpulse.theaslangroupllc.com` | 10 | $0.08–$0.15 | BuildPulse — home construction and renovation intelligence: project cost estimates, contractor vetting, permit requirements, material |
+| `https://proppulse.theaslangroupllc.com` | 13 | $0.05–$2 | Global real estate intelligence API — 11 endpoints covering the full property lifecycle in any country. Mortgage/remortgage analysis, |
+
+## Science, Climate, Energy & Mobility
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://climatepulse.theaslangroupllc.com` | 11 | $0.05–$0.5 | Global climate and weather intelligence API. MET Norway real-time weather + AI synthesis. Severe weather assessment, air quality |
+| `https://biopulse.theaslangroupllc.com` | 9 | $0.08–$0.12 | Global biodiversity intelligence API. GBIF + IUCN + eBird + iNaturalist data synthesis. Species profiles, IUCN conservation status, |
+| `https://gridpulse.theaslangroupllc.com` | 14 | $0.01–$0.25 | Global energy grid intelligence API. NREL + EIA + Open-Meteo data synthesis. Home solar feasibility, electricity rate analysis, time-of-use |
+| `https://waterpulse.theaslangroupllc.com` | 10 | $0.01–$0.5 | Global water intelligence API. 9 endpoints covering US groundwater (USGS), streamflow, drought (US Drought Monitor), water quality (EPA |
+| `https://fieldpulse.theaslangroupllc.com` | 10 | $0.05–$0.2 | Global precision agriculture intelligence API. Synthesizes satellite NDVI data, MET Norway weather forecasts (CC BY 4.0), NASA POWER soil |
+| `https://harvestpulse.theaslangroupllc.com` | 15 | $0.05–$0.15 | Global farm-to-table and agricultural intelligence API. USDA + ERS data synthesis. Local food finder (farmers markets, CSAs, on-farm |
+| `https://autopulse.theaslangroupllc.com` | 12 | $0.02–$0.15 | Automotive intelligence API — 11 endpoints powered by NHTSA, EPA, and live market data. Safety recalls, reliability analysis, DIY repair |
+| `https://cyberpulse.theaslangroupllc.com` | 11 | $0.02–$0.25 | Global cybersecurity intelligence API — CVE briefs, vulnerability scanning, CISA KEV, OSINT, threat intelligence, ransomware tracking, |
+| `https://transitpulse.theaslangroupllc.com` | 16 | $0.05–$2 | TransitPulse — global public transit intelligence: route reliability, delay prediction, multi-modal trip planning, city transit scores, and |
+| `https://travelpulse.theaslangroupllc.com` | 20 | $0.03–$2 | Global travel intelligence API for AI agents: weather, hotel deals, theme-park wait times, translation, trip plans, visas, health, |
+
+## Sports, Gaming & Culture
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://footballpulse.theaslangroupllc.com` | 11 | $0.1–$0.25 | Football/soccer intelligence for fans, fantasy managers, and betting analysts — Fantasy Premier League checks grounded in the official FPL |
+| `https://stateedge.theaslangroupllc.com` | 6 | $0.08–$0.1 | Global sports analytics and intelligence API. AI-synthesized injury reports, ATS/spread analysis, matchup predictions, odds analysis, |
+| `https://racingpulse.theaslangroupllc.com` | 13 | $0.02–$0.07 | Global horse racing intelligence — live odds, going conditions, form analysis, arbitrage detection, speed ratings, and betting systems for |
+| `https://gamepulse.theaslangroupllc.com` | 20 | $0.05–$0.25 | Gaming economy intelligence API — play, trade, and earn. Live in-game item (skins) price checks across Steam Market and Skinport with real |
+| `https://fanpulse.theaslangroupllc.com` | 9 | $0.08–$0.15 | Global fandom intelligence API. AI-synthesized fan guides, lore analysis, collectibles valuation, discography deep-dives, character |
+| `https://collectablespulse.theaslangroupllc.com` | 11 | $0.08–$0.15 | Global collectibles market intelligence API. AI-synthesized valuations for sports cards, coins, comics, vinyl records, Pokémon/MTG/TCGs, |
+| `https://chronicapulse.theaslangroupllc.com` | 9 | $0.05–$0.15 | Global genealogy and historical archive intelligence API. Full-text search across Chronicling America (1770–1963 US newspapers), Library of |
+

--- a/mcp/skills/pulse-network/rules/origins.md
+++ b/mcp/skills/pulse-network/rules/origins.md
@@ -98,3 +98,9 @@ All origins follow `https://<name>.theaslangroupllc.com`. Every origin serves `/
 | `https://collectablespulse.theaslangroupllc.com` | 11 | $0.08–$0.15 | Global collectibles market intelligence API. AI-synthesized valuations for sports cards, coins, comics, vinyl records, Pokémon/MTG/TCGs, |
 | `https://chronicapulse.theaslangroupllc.com` | 9 | $0.05–$0.15 | Global genealogy and historical archive intelligence API. Full-text search across Chronicling America (1770–1963 US newspapers), Library of |
 
+## Fulfillment & Actions
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://mailpulse.theaslangroupllc.com` | 3 | $0.005–$14 | The fleet's first ACTION origin — does something in the world instead of answering a question. Sends a real physical letter (US First-Class, US Certified with optional return receipt, or international) via USPS through Lob's Print & Mail network: paying causes real postage to print and mail. Free address-deliverability check and free price quote precede the paid send; cheap status/tracking poll afterward. Good referral target from correspondence-heavy verticals (IRS/USCIS notices, demand letters). |
+

--- a/skills/pulse-network/SKILL.md
+++ b/skills/pulse-network/SKILL.md
@@ -31,7 +31,7 @@ metadata:
 
 66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
-Catalog: https://mcp-pulsenetwork.vercel.app · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+Catalog: https://pulsenetwork.theaslangroupllc.com · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
 ## Setup
 

--- a/skills/pulse-network/SKILL.md
+++ b/skills/pulse-network/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pulse-network
 description: |
-  Vertical intelligence APIs across 66 x402 origins (826 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
+  Vertical intelligence APIs across 67 x402 origins (827 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
 
   USE FOR:
   - Sanctions/OFAC screening, EU VAT validation, GLEIF LEI lookups
@@ -12,6 +12,7 @@ description: |
   - FDIC bank-health checks, credit-card benefit coverage
   - Real-time weather/air quality, earthquake checks, country risk
   - Deep verticals: healthcare prices, clinical trials, grants, patents, real estate, transit, racing, esports — see rules/origins.md
+  - Send real physical mail (USPS letters, certified mail with tracking) — an ACTION endpoint, not a lookup
 
   TRIGGERS:
   - "sanctions check", "OFAC", "screen this entity", "validate VAT", "LEI"
@@ -21,6 +22,7 @@ description: |
   - "tax rate in", "VAT in", "visa requirements"
   - "is my bank safe", "FDIC", "card benefit"
   - "country risk", "travel safety", "air quality"
+  - "send a letter", "mail this", "certified mail", "USPS tracking"
 
   All origins share one pattern: `https://<vertical>.theaslangroupllc.com`. Use `npx agentcash@latest discover <origin>` to enumerate any origin, and `npx agentcash@latest fetch` to call endpoints.
 metadata:
@@ -29,7 +31,7 @@ metadata:
 
 # PulseNetwork — Vertical Intelligence APIs
 
-66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
+67 single-purpose x402 API origins (827 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
 Catalog: https://pulsenetwork.theaslangroupllc.com · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
@@ -54,8 +56,10 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 | Real-time air quality + health risk | `https://climatepulse.theaslangroupllc.com/api/climate/air` | $0.05 |
 | Country risk assessment | `https://geopoliticalpulse.theaslangroupllc.com/api/geopolitical/country-risk` | $0.15 |
 | AI-visibility check of any website (verbatim evidence) | `https://marketpulse.theaslangroupllc.com/api/market/ai-visibility-check` | $0.50 |
+| Send a real physical letter — USPS, first-class/certified/international (ACTION: prints & mails on payment) | `https://mailpulse.theaslangroupllc.com/api/letters` | $3–$14 |
+| Verify a mailing address before sending physical mail (USPS-backed) | `https://mailpulse.theaslangroupllc.com/api/verify-address` | $0.01 |
 
-Full directory of all 66 origins grouped by category: [rules/origins.md](rules/origins.md).
+Full directory of all 67 origins grouped by category: [rules/origins.md](rules/origins.md).
 
 ## Workflow
 

--- a/skills/pulse-network/SKILL.md
+++ b/skills/pulse-network/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: pulse-network
+description: |
+  Vertical intelligence APIs across 66 x402 origins (826 paid endpoints): compliance screening, crypto/token safety, SEC filings, tax, legal, climate, health, sports, and more. Deterministic primitives from $0.01.
+
+  USE FOR:
+  - Sanctions/OFAC screening, EU VAT validation, GLEIF LEI lookups
+  - Pre-trade token safety scans (Solana memecoins, EVM tokens, multi-chain)
+  - SEC/EDGAR fundamentals, filing search, 13F due diligence
+  - Perp funding rates, arbitrage math, FX-premium signals (Hyperliquid, dYdX)
+  - Tax rates and VAT/GST for 195 countries; global visa/immigration checks
+  - FDIC bank-health checks, credit-card benefit coverage
+  - Real-time weather/air quality, earthquake checks, country risk
+  - Deep verticals: healthcare prices, clinical trials, grants, patents, real estate, transit, racing, esports — see rules/origins.md
+
+  TRIGGERS:
+  - "sanctions check", "OFAC", "screen this entity", "validate VAT", "LEI"
+  - "is this token safe", "memecoin check", "rug check", "scan token"
+  - "SEC filing", "10-K", "13F", "company fundamentals"
+  - "funding rate", "arbitrage", "stablecoin premium"
+  - "tax rate in", "VAT in", "visa requirements"
+  - "is my bank safe", "FDIC", "card benefit"
+  - "country risk", "travel safety", "air quality"
+
+  All origins share one pattern: `https://<vertical>.theaslangroupllc.com`. Use `npx agentcash@latest discover <origin>` to enumerate any origin, and `npx agentcash@latest fetch` to call endpoints.
+metadata:
+  version: 1
+---
+
+# PulseNetwork — Vertical Intelligence APIs
+
+66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
+
+Catalog: https://www.pulsenetwork.dev · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference — flagship endpoints
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| OFAC sanctions screen (alias-aware, deterministic) | `https://compliancepulse.theaslangroupllc.com/api/screen/sanctions` | $0.02 |
+| EU VAT number validation (VIES, deterministic) | `https://compliancepulse.theaslangroupllc.com/api/validate/vat` | $0.01 |
+| Solana memecoin pre-trade scan (deterministic verdict) | `https://onchainpulse.theaslangroupllc.com/api/memecoin` | $0.015 |
+| EVM token pre-trade scan (multi-chain) | `https://onchainpulse.theaslangroupllc.com/api/evmtoken` | $0.015 |
+| SEC XBRL fundamentals — 8 quarters, deterministic | `https://filingspulse.theaslangroupllc.com/api/filings/quarterly` | $0.02 |
+| Perp funding-rate check (cross-venue normalized) | `https://cryptopulse.theaslangroupllc.com/api/funding-check` | $0.02 |
+| Stablecoin parallel-rate FX premium signal | `https://arbipulse.theaslangroupllc.com/api/fx-premium` | $0.02 |
+| FDIC bank-health check (Call Report primitive) | `https://wealthpulse.theaslangroupllc.com/api/wealth/bank-check` | $0.02 |
+| Country tax system overview (195 countries) | `https://taxpulse.theaslangroupllc.com/api/tax/country` | $0.10 |
+| Earthquake activity check (USGS, deterministic) | `https://riskpulse.theaslangroupllc.com/api/risk/quake-check` | $0.01 |
+| Real-time air quality + health risk | `https://climatepulse.theaslangroupllc.com/api/climate/air` | $0.05 |
+| Country risk assessment | `https://geopoliticalpulse.theaslangroupllc.com/api/geopolitical/country-risk` | $0.15 |
+| AI-visibility check of any website (verbatim evidence) | `https://marketpulse.theaslangroupllc.com/api/market/ai-visibility-check` | $0.50 |
+
+Full directory of all 66 origins grouped by category: [rules/origins.md](rules/origins.md).
+
+## Workflow
+
+1. **Pick an origin** from the task → category mapping in [rules/origins.md](rules/origins.md) (or the Quick Reference above).
+2. **Discover** its endpoints and prices:
+   ```bash
+   npx agentcash@latest discover https://compliancepulse.theaslangroupllc.com
+   ```
+3. **Check** a specific endpoint's schema and price before first use:
+   ```bash
+   npx agentcash@latest check https://compliancepulse.theaslangroupllc.com/api/screen/sanctions
+   ```
+4. **Fetch** (most endpoints are GET with query params):
+   ```bash
+   npx agentcash@latest fetch "https://compliancepulse.theaslangroupllc.com/api/screen/sanctions?name=ACME%20Trading%20Ltd"
+   ```
+
+## Examples
+
+Sanctions screen before a payment:
+
+```bash
+npx agentcash@latest fetch "https://compliancepulse.theaslangroupllc.com/api/screen/sanctions?name=Example%20Corp"
+```
+
+Token safety scan before a trade:
+
+```bash
+npx agentcash@latest fetch "https://onchainpulse.theaslangroupllc.com/api/memecoin?mint=<SOLANA_MINT_ADDRESS>"
+```
+
+Eight quarters of reported fundamentals for a ticker:
+
+```bash
+npx agentcash@latest fetch "https://filingspulse.theaslangroupllc.com/api/filings/quarterly?company=NVDA"
+```
+
+Country tax overview:
+
+```bash
+npx agentcash@latest fetch "https://taxpulse.theaslangroupllc.com/api/tax/country?country=Portugal"
+```
+
+## Notes
+
+- Unpaid requests return a standard x402 402 challenge (before body validation) with exact price and pay-to details.
+- Endpoints marked "deterministic" return primary-source data with no LLM synthesis — stable output for a given input, suitable for agent pipelines.
+- Upstream failures return 4xx/5xx without settling payment.
+- Questions: info@theaslangroupllc.com

--- a/skills/pulse-network/SKILL.md
+++ b/skills/pulse-network/SKILL.md
@@ -31,7 +31,7 @@ metadata:
 
 66 single-purpose x402 API origins (826 paid endpoints) operated by The Aslan Group LLC, covering finance, compliance, legal, tax, health, climate, energy, sports, and consumer verticals. USDC on Base mainnet (eip155:8453), Coinbase Developer Platform facilitator. No accounts, no API keys.
 
-Catalog: https://www.pulsenetwork.dev · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
+Catalog: https://mcp-pulsenetwork.vercel.app · Every origin serves `/openapi.json`, `/.well-known/agent.json`, and `/llms.txt`.
 
 ## Setup
 

--- a/skills/pulse-network/rules/getting-started.md
+++ b/skills/pulse-network/rules/getting-started.md
@@ -1,0 +1,25 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |

--- a/skills/pulse-network/rules/origins.md
+++ b/skills/pulse-network/rules/origins.md
@@ -1,0 +1,100 @@
+# PulseNetwork Origin Directory
+
+All origins follow `https://<name>.theaslangroupllc.com`. Every origin serves `/openapi.json` (with per-route `x-payment-info` pricing), `/.well-known/agent.json`, and `/llms.txt`. Discover any origin with `npx agentcash@latest discover <origin>`.
+
+## Finance & Markets
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://alphapulse.theaslangroupllc.com` | 13 | $0.08–$0.5 | The due-diligence layer for traders and allocators, worldwide — check before you fund. Official SEC EDGAR 13F hedge-fund holdings fetched |
+| `https://arbipulse.theaslangroupllc.com` | 15 | $0.02–$0.75 | The arbitrage layer for every market — 18 endpoints finding the same thing at two prices. Beyond-finance lanes: prediction-market |
+| `https://cryptopulse.theaslangroupllc.com` | 24 | $0.02–$0.5 | Global cryptocurrency intelligence API. 10 endpoints: DeFi yield farming across Ethereum/Base/Arbitrum/Solana (DeFiLlama live TVL + APY), |
+| `https://onchainpulse.theaslangroupllc.com` | 15 | $0.015–$0.25 | Intelligence API for the onchain financial transition. Decodes legislation, tracks RWA tokenization, models sector scenarios, guides |
+| `https://filingspulse.theaslangroupllc.com` | 15 | $0.02–$0.25 | Global SEC/EDGAR and international filings intelligence API. AI-synthesized plain-language summaries of 10-K, 10-Q, 8-K, S-1/IPO filings. |
+| `https://wealthpulse.theaslangroupllc.com` | 18 | $0.02–$2 | Personal finance intelligence API. 14 endpoints grounded in live FRED rate data and official FDIC Call Report data — financial health, |
+| `https://venturepulse.theaslangroupllc.com` | 10 | $0.1–$0.2 | Startup funding intelligence API. VC round data, investor matching, pitch deck scoring, term sheet decoding, cap table modeling, global |
+| `https://econsignalpulse.theaslangroupllc.com` | 10 | $0.08–$0.25 | Alternative economic intelligence API covering 190+ countries. Combines World Bank Open Data, IMF Datamapper forecasts, satellite nighttime |
+| `https://prospectpulse.theaslangroupllc.com` | 10 | $0.1–$0.35 | Global mineral and resource exploration intelligence. USGS MRDS deposit inventory, geochemical anomaly analysis, satellite scene |
+
+## Compliance, Legal & Government
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://compliancepulse.theaslangroupllc.com` | 14 | $0.01–$1.5 | Global regulatory intelligence API. 13 endpoints. Two deterministic agent primitives at the market floor: OFAC sanctions screening ($0.02) |
+| `https://legalpulse.theaslangroupllc.com` | 12 | $0.08–$2 | The clearance layer before you sign, send, or sue — 12 endpoints for legal agents and the people they work for. Pre-signature contract |
+| `https://policypulse.theaslangroupllc.com` | 14 | $0.02–$0.2 | PolicyPulse — global legislative intelligence: US Congress, EU (EUR-Lex), UK Parliament, India, Brazil, Australia, and 50+ jurisdictions. |
+| `https://taxpulse.theaslangroupllc.com` | 15 | $0.1–$12 | Global tax intelligence API. AI-synthesized tax guidance for 195 countries: income tax rates, VAT/GST, corporate tax, capital gains, crypto |
+| `https://riskpulse.theaslangroupllc.com` | 11 | $0.01–$0.15 | Global risk intelligence API. AI-synthesized travel safety alerts, country risk profiles, sanctions screening, business risk analysis, |
+| `https://geopoliticalpulse.theaslangroupllc.com` | 10 | $0.15–$0.25 | Real-time geopolitical intelligence for investors, compliance teams, and AI agents. Political risk, conflict monitoring, sanctions, |
+| `https://govspendpulse.theaslangroupllc.com` | 9 | $0.08–$0.2 | Global government procurement intelligence API. 9 endpoints covering US federal contracts (USASpending.gov), active solicitations |
+| `https://truthpulse.theaslangroupllc.com` | 11 | $0.08–$0.2 | Primary-source intelligence for FOIA releases, declassified archives, court records, forensic evidence, UAP disclosures, and conspiracy |
+| `https://patentpulse.theaslangroupllc.com` | 11 | $0.05–$0.2 | PatentPulse — global IP intelligence: USPTO/EPO/WIPO/JPO/CNIPA patent search, FTO analysis, SEP licensing, trademark clearance, prior art, |
+| `https://immigrationpulse.theaslangroupllc.com` | 12 | $0.05–$0.2 | Global immigration intelligence API serving 281M+ migrants. 11 endpoints covering visa requirements, PR pathways, points calculators |
+| `https://tradepulse.theaslangroupllc.com` | 12 | $0.08–$0.2 | Global trade intelligence API. AI-synthesized tariff rates, HS code classification, FTA duty analysis, landed cost calculation, trade |
+| `https://esgpulse.theaslangroupllc.com` | 17 | $0.05–$0.25 | AI-powered ESG and sustainability intelligence: CSRD compliance roadmaps, EU Taxonomy alignment, supply chain due diligence, emissions |
+
+## Business, Careers & Funding
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://marketpulse.theaslangroupllc.com` | 12 | $0.08–$0.5 | The AI-visibility layer for businesses anywhere in the world — get found by the assistants doing the choosing. Live AI-visibility check |
+| `https://dealpulse.theaslangroupllc.com` | 13 | $0.05–$2 | Deal verification and intelligence API. deal-check verifies which offers are REAL at any store, first-party sources only with source URLs |
+| `https://findpulse.theaslangroupllc.com` | 13 | $0.05–$0.5 | Universal finder and discovery API — the research layer before the transaction, built for shopping and buyer agents. Pre-purchase |
+| `https://franchisepulse.theaslangroupllc.com` | 9 | $0.08–$0.2 | Global franchise intelligence API. AI-synthesized franchise discovery, FDD analysis, total cost modeling, SBA loan analysis, resale |
+| `https://careerpulse.theaslangroupllc.com` | 13 | $0.05–$2 | Global career intelligence API serving the world's 3.5 billion workers. 10 endpoints: salary benchmarking (any role + any country, sourced |
+| `https://talentpulse.theaslangroupllc.com` | 10 | $0.1–$0.25 | Global workforce intelligence API — salary benchmarks, remote compliance, EOR cost models, skills demand, work visas, talent market |
+| `https://grantpulse.theaslangroupllc.com` | 14 | $0.08–$2 | The funding-discovery layer for organisations anywhere — grounded in official sources fetched live: Grants.gov, the EU Funding & Tenders |
+| `https://scholarpulse.theaslangroupllc.com` | 13 | $0.08–$0.15 | Global scholarship and student finance intelligence. 13 endpoints covering scholarship search (190+ countries), international scholarship |
+| `https://edupulse.theaslangroupllc.com` | 19 | $0.05–$5 | Global education intelligence API — 18 endpoints for students, test-takers, homeschool families, and lifelong learners worldwide. Study |
+
+## Health, Home & Personal Finance
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://clearcarepulse.theaslangroupllc.com` | 10 | $0.05–$5 | Healthcare price transparency and cost navigation API. AI-synthesized procedure price search, cash-pay alternatives, hospital quality |
+| `https://clinicalintelpulse.theaslangroupllc.com` | 14 | $0.02–$0.35 | Pharmaceutical pipeline and clinical trial intelligence API. Synthesizes 400,000+ registered trials from ClinicalTrials.gov with FDA |
+| `https://herbapulse.theaslangroupllc.com` | 10 | $0.08–$0.25 | Global herbal medicine and botanical intelligence API. PubMed-grounded herb profiles, drug-herb interaction checker, traditional medicine |
+| `https://nutripulse.theaslangroupllc.com` | 15 | $0.02–$0.15 | Global nutrition intelligence API. PubMed-grounded supplement analysis, macro/micronutrient planning, food database lookups, |
+| `https://mindpulse.theaslangroupllc.com` | 11 | $0.08–$0.1 | Global mental health intelligence API. Evidence-based guidance on therapy platform matching, mental health assessment, burnout, psychiatric |
+| `https://longevitypulse.theaslangroupllc.com` | 11 | $0.1–$0.25 | Global longevity intelligence API — biomarker interpretation, supplement evidence, personalized protocols, clinical trials, Blue Zone |
+| `https://fitpulse.theaslangroupllc.com` | 10 | $0.08–$0.1 | Global fitness intelligence API. Evidence-based workout programming, nutrition science, supplement efficacy analysis, injury recovery |
+| `https://mealpulse.theaslangroupllc.com` | 10 | $0.05–$0.15 | Global meal planning and culinary intelligence API. AI-synthesized meal plans, recipe generation, dietary restriction guidance, grocery |
+| `https://petpulse.theaslangroupllc.com` | 12 | $0.08–$0.1 | Global pet health and care intelligence API. AI-synthesized veterinary symptom triage, breed selection guides, pet nutrition analysis, |
+| `https://parentpulse.theaslangroupllc.com` | 10 | $0.08–$0.12 | ParentPulse — child development and parenting intelligence: developmental milestones, nutrition guidance, pediatric health, sleep science, |
+| `https://seniorpulse.theaslangroupllc.com` | 14 | $0.08–$0.15 | Global elder care intelligence API. AI-synthesized Medicare/pension guidance, care facility evaluation, medication safety, benefits |
+| `https://vetpulse.theaslangroupllc.com` | 10 | $0.05–$0.2 | Global veterans benefits intelligence API. AI-synthesized guidance on disability compensation, Aid & Attendance-style pensions, |
+| `https://safepulse.theaslangroupllc.com` | 9 | $0.08–$0.12 | SafePulse — product safety intelligence: CPSC, FDA, USDA FSIS, NHTSA recalls; EU RAPEX; home safety scores; child/vehicle safety ratings; |
+| `https://insurepulse.theaslangroupllc.com` | 14 | $0.05–$2 | AI-synthesized insurance intelligence. Auto coverage analysis, life insurance needs calculator, homeowners gap finder, annual coverage |
+| `https://debtpulse.theaslangroupllc.com` | 21 | $0.05–$0.2 | Global debt elimination intelligence. All endpoints require x402 payment (USDC on Base mainnet) via the PAYMENT-SIGNATURE header. Supports |
+| `https://remittancepulse.theaslangroupllc.com` | 11 | $0.05–$2 | Global remittance intelligence API covering the $700B+ annual global remittance market. 9 endpoints: corridor analysis (200+ corridors), |
+| `https://homepulse.theaslangroupllc.com` | 10 | $0.08–$0.1 | Global home intelligence API. AI-synthesized home maintenance checklists, improvement ROI analysis, neighborhood research, smart home |
+| `https://buildpulse.theaslangroupllc.com` | 10 | $0.08–$0.15 | BuildPulse — home construction and renovation intelligence: project cost estimates, contractor vetting, permit requirements, material |
+| `https://proppulse.theaslangroupllc.com` | 13 | $0.05–$2 | Global real estate intelligence API — 11 endpoints covering the full property lifecycle in any country. Mortgage/remortgage analysis, |
+
+## Science, Climate, Energy & Mobility
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://climatepulse.theaslangroupllc.com` | 11 | $0.05–$0.5 | Global climate and weather intelligence API. MET Norway real-time weather + AI synthesis. Severe weather assessment, air quality |
+| `https://biopulse.theaslangroupllc.com` | 9 | $0.08–$0.12 | Global biodiversity intelligence API. GBIF + IUCN + eBird + iNaturalist data synthesis. Species profiles, IUCN conservation status, |
+| `https://gridpulse.theaslangroupllc.com` | 14 | $0.01–$0.25 | Global energy grid intelligence API. NREL + EIA + Open-Meteo data synthesis. Home solar feasibility, electricity rate analysis, time-of-use |
+| `https://waterpulse.theaslangroupllc.com` | 10 | $0.01–$0.5 | Global water intelligence API. 9 endpoints covering US groundwater (USGS), streamflow, drought (US Drought Monitor), water quality (EPA |
+| `https://fieldpulse.theaslangroupllc.com` | 10 | $0.05–$0.2 | Global precision agriculture intelligence API. Synthesizes satellite NDVI data, MET Norway weather forecasts (CC BY 4.0), NASA POWER soil |
+| `https://harvestpulse.theaslangroupllc.com` | 15 | $0.05–$0.15 | Global farm-to-table and agricultural intelligence API. USDA + ERS data synthesis. Local food finder (farmers markets, CSAs, on-farm |
+| `https://autopulse.theaslangroupllc.com` | 12 | $0.02–$0.15 | Automotive intelligence API — 11 endpoints powered by NHTSA, EPA, and live market data. Safety recalls, reliability analysis, DIY repair |
+| `https://cyberpulse.theaslangroupllc.com` | 11 | $0.02–$0.25 | Global cybersecurity intelligence API — CVE briefs, vulnerability scanning, CISA KEV, OSINT, threat intelligence, ransomware tracking, |
+| `https://transitpulse.theaslangroupllc.com` | 16 | $0.05–$2 | TransitPulse — global public transit intelligence: route reliability, delay prediction, multi-modal trip planning, city transit scores, and |
+| `https://travelpulse.theaslangroupllc.com` | 20 | $0.03–$2 | Global travel intelligence API for AI agents: weather, hotel deals, theme-park wait times, translation, trip plans, visas, health, |
+
+## Sports, Gaming & Culture
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://footballpulse.theaslangroupllc.com` | 11 | $0.1–$0.25 | Football/soccer intelligence for fans, fantasy managers, and betting analysts — Fantasy Premier League checks grounded in the official FPL |
+| `https://stateedge.theaslangroupllc.com` | 6 | $0.08–$0.1 | Global sports analytics and intelligence API. AI-synthesized injury reports, ATS/spread analysis, matchup predictions, odds analysis, |
+| `https://racingpulse.theaslangroupllc.com` | 13 | $0.02–$0.07 | Global horse racing intelligence — live odds, going conditions, form analysis, arbitrage detection, speed ratings, and betting systems for |
+| `https://gamepulse.theaslangroupllc.com` | 20 | $0.05–$0.25 | Gaming economy intelligence API — play, trade, and earn. Live in-game item (skins) price checks across Steam Market and Skinport with real |
+| `https://fanpulse.theaslangroupllc.com` | 9 | $0.08–$0.15 | Global fandom intelligence API. AI-synthesized fan guides, lore analysis, collectibles valuation, discography deep-dives, character |
+| `https://collectablespulse.theaslangroupllc.com` | 11 | $0.08–$0.15 | Global collectibles market intelligence API. AI-synthesized valuations for sports cards, coins, comics, vinyl records, Pokémon/MTG/TCGs, |
+| `https://chronicapulse.theaslangroupllc.com` | 9 | $0.05–$0.15 | Global genealogy and historical archive intelligence API. Full-text search across Chronicling America (1770–1963 US newspapers), Library of |
+

--- a/skills/pulse-network/rules/origins.md
+++ b/skills/pulse-network/rules/origins.md
@@ -98,3 +98,9 @@ All origins follow `https://<name>.theaslangroupllc.com`. Every origin serves `/
 | `https://collectablespulse.theaslangroupllc.com` | 11 | $0.08–$0.15 | Global collectibles market intelligence API. AI-synthesized valuations for sports cards, coins, comics, vinyl records, Pokémon/MTG/TCGs, |
 | `https://chronicapulse.theaslangroupllc.com` | 9 | $0.05–$0.15 | Global genealogy and historical archive intelligence API. Full-text search across Chronicling America (1770–1963 US newspapers), Library of |
 
+## Fulfillment & Actions
+
+| Origin | Endpoints | Price range | What it does |
+|---|---|---|---|
+| `https://mailpulse.theaslangroupllc.com` | 3 | $0.005–$14 | The fleet's first ACTION origin — does something in the world instead of answering a question. Sends a real physical letter (US First-Class, US Certified with optional return receipt, or international) via USPS through Lob's Print & Mail network: paying causes real postage to print and mail. Free address-deliverability check and free price quote precede the paid send; cheap status/tracking poll afterward. Good referral target from correspondence-heavy verticals (IRS/USCIS notices, demand letters). |
+


### PR DESCRIPTION
Adds a `pulse-network` skill (CLI + MCP variants) covering PulseNetwork — 66 single-purpose x402 API origins / 826 paid endpoints operated by The Aslan Group LLC: sanctions/OFAC screening, EU VAT validation, pre-trade token safety scans, SEC XBRL fundamentals, perp funding rates, tax intelligence for 195 countries, FDIC bank health, climate/air quality, country risk, and ~60 more verticals. Deterministic primitives start at $0.01.

- USDC on Base mainnet, CDP facilitator, no accounts or API keys
- Every origin serves `/openapi.json` with per-route `x-payment-info`, `/.well-known/agent.json`, and `/llms.txt`, and validates with `npx @agentcash/discovery check`
- All origins registered on x402scan
- SKILL.md carries a flagship quick-reference; the full 66-origin directory grouped by category lives in `rules/origins.md`
- Example commands verified against live endpoints (params checked against each origin's OpenAPI spec)

Catalog: https://www.pulsenetwork.dev · Contact: info@theaslangroupllc.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)