### PR TITLE
Add kelam-phone-calls skill (real AI phone calls + voice agents via x402)

### DIFF
--- a/mcp/skills/kelam-phone-calls/SKILL.md
+++ b/mcp/skills/kelam-phone-calls/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: kelam-phone-calls
+description: |
+  Real outbound AI phone calls in the most realistic voices, and your own inbound/outbound
+  voice agents, via x402 at call.kelam.sh -- a fraction of what managed voice-AI platforms cost.
+
+  USE FOR:
+  - Placing a real outbound phone call to accomplish a task (book, confirm, chase, ask) and getting the transcript + outcome back
+  - Extracting typed fields from a call (a quoted price, a yes/no, a date)
+  - Provisioning your own inbound or outbound voice agent under your wallet
+  - Topping up prepaid credits so an inbound agent can answer
+  - Designing/editing an agent in plain English with the builder
+
+  TRIGGERS:
+  - "call", "phone call", "make a call", "dial", "voicemail"
+  - "voice agent", "receptionist", "answer my phone", "book by phone"
+  - "transcript", "call outcome", "call summary"
+
+  ALWAYS use agentcash.fetch for call.kelam.sh endpoints.
+mcp:
+  - agentcash
+metadata:
+  version: 1
+---
+
+# Real AI Phone Calls with Kelam
+
+Place real phone calls and provision voice agents via x402 payments at `https://call.kelam.sh`.
+The most realistic voices, billed to the second, a fraction of what managed voice-AI platforms cost.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for CLI install and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| Place an outbound call | `POST https://call.kelam.sh/api/place_call` | $0.05 + $0.15/min (capped $2) |
+| Check call status | `GET https://call.kelam.sh/api/call_status?call_id=...` | Free |
+| Create a voice agent | `POST https://call.kelam.sh/api/create_agent` | $2.00 |
+| Top up inbound credits | `POST https://call.kelam.sh/api/top_up` | $0.40 per call |
+| Talk to the agent builder | `POST https://call.kelam.sh/api/build` | $0.40 per message |
+| Allowlist a caller | `POST https://call.kelam.sh/api/allowlist_number` | Free |
+| List your agents | `GET https://call.kelam.sh/api/list_agents` | Free |
+| Credit balance | `GET https://call.kelam.sh/api/balance` | Free |
+| Builder transcript | `GET https://call.kelam.sh/api/build_view?session_id=...` | Free |
+
+An outbound call is metered by talk time ($0.05 connect + $0.15/min, billed to the second, capped at $2.00). A call that never reaches anyone is free.
+
+## Place a Call
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/place_call",
+  method="POST",
+  body={
+    "to": "+14155551234",
+    "task": "Call this restaurant and book a table for 4 tonight at 7pm under the name Sami. Confirm the exact time.",
+    "extract": [{"name": "booked", "type": "boolean", "description": "did they confirm the reservation"}]
+  }
+)
+```
+
+Returns `{ call_id, status, answered_by, duration_seconds, summary, outcome, transcript, recording_url, price_usd }`.
+A call reaching no one (busy / no answer) is free.
+
+## Create a Voice Agent
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/create_agent",
+  method="POST",
+  body={"name": "front-desk", "instructions": "You are a friendly dental receptionist. Book appointments and answer questions."}
+)
+```
+
+Returns `{ agent_id, phone_number, inbound }`. Requires wallet auth (SIWX).
+
+IMPORTANT: an inbound agent answers a caller only after you BOTH fund it (`top_up`) AND allowlist
+that caller (`allowlist_number`, or `allow_callers` at create time). Until both are done it
+silently rejects every inbound call.
+
+## Talk to the Builder
+
+Design or edit an agent in plain English. Omit `session_id` to start (the reply carries one);
+pass it back to continue. Replies are read for free with `build_view`.
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/build",
+  method="POST",
+  body={"message": "Build me a receptionist for a dentist that books appointments and takes messages."}
+)
+```

--- a/mcp/skills/kelam-phone-calls/rules/getting-started.md
+++ b/mcp/skills/kelam-phone-calls/rules/getting-started.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check your wallet balance:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund your wallet** (USDC on Base) if needed:
+   - Redeem an invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` for Base/Solana deposit links + addresses
+
+4. **Discover the endpoints:**
+   ```bash
+   npx agentcash@latest discover https://call.kelam.sh
+   ```
+
+## Inbound agents need TWO things
+
+An agent you create with `inbound: true` answers a caller only when BOTH are true:
+
+1. **It is funded** -- buy prepaid credits with `top_up` (each answered inbound call spends one).
+2. **The caller is allowlisted** -- pass `allow_callers` at create time, or call `allowlist_number` later.
+
+Until both are done, the agent silently rejects every inbound call.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund your wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient errors) |
+| Inbound call not answered | Confirm the agent is funded (`top_up`) AND the caller is allowlisted |
+| Wrong endpoint | Use the exact paths from the Quick Reference in SKILL.md |
+
+## Pricing Reference
+
+| Endpoint | Price |
+|----------|-------|
+| place_call | $0.05 connect + $0.15/min (billed to the second, capped $2.00; unconnected = free) |
+| create_agent | $2.00 |
+| top_up | $0.40 per prepaid inbound call |
+| build | $0.40 per builder message |
+| call_status / list_agents / balance / allowlist_number / build_view | Free |

--- a/skills/kelam-phone-calls/SKILL.md
+++ b/skills/kelam-phone-calls/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: kelam-phone-calls
+description: |
+  Real outbound AI phone calls in the most realistic voices, and your own inbound/outbound
+  voice agents, via x402 at call.kelam.sh -- a fraction of what managed voice-AI platforms cost.
+
+  USE FOR:
+  - Placing a real outbound phone call to accomplish a task (book, confirm, chase, ask) and getting the transcript + outcome back
+  - Extracting typed fields from a call (a quoted price, a yes/no, a date)
+  - Provisioning your own inbound or outbound voice agent under your wallet
+  - Topping up prepaid credits so an inbound agent can answer
+  - Designing/editing an agent in plain English with the builder
+
+  TRIGGERS:
+  - "call", "phone call", "make a call", "dial", "voicemail"
+  - "voice agent", "receptionist", "answer my phone", "book by phone"
+  - "transcript", "call outcome", "call summary"
+
+  ALWAYS use agentcash.fetch for call.kelam.sh endpoints.
+mcp:
+  - agentcash
+metadata:
+  version: 1
+---
+
+# Real AI Phone Calls with Kelam
+
+Place real phone calls and provision voice agents via x402 payments at `https://call.kelam.sh`.
+The most realistic voices, billed to the second, a fraction of what managed voice-AI platforms cost.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for CLI install and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price |
+|------|----------|-------|
+| Place an outbound call | `POST https://call.kelam.sh/api/place_call` | $0.05 + $0.15/min (capped $2) |
+| Check call status | `GET https://call.kelam.sh/api/call_status?call_id=...` | Free |
+| Create a voice agent | `POST https://call.kelam.sh/api/create_agent` | $2.00 |
+| Top up inbound credits | `POST https://call.kelam.sh/api/top_up` | $0.40 per call |
+| Talk to the agent builder | `POST https://call.kelam.sh/api/build` | $0.40 per message |
+| Allowlist a caller | `POST https://call.kelam.sh/api/allowlist_number` | Free |
+| List your agents | `GET https://call.kelam.sh/api/list_agents` | Free |
+| Credit balance | `GET https://call.kelam.sh/api/balance` | Free |
+| Builder transcript | `GET https://call.kelam.sh/api/build_view?session_id=...` | Free |
+
+An outbound call is metered by talk time ($0.05 connect + $0.15/min, billed to the second, capped at $2.00). A call that never reaches anyone is free.
+
+## Place a Call
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/place_call",
+  method="POST",
+  body={
+    "to": "+14155551234",
+    "task": "Call this restaurant and book a table for 4 tonight at 7pm under the name Sami. Confirm the exact time.",
+    "extract": [{"name": "booked", "type": "boolean", "description": "did they confirm the reservation"}]
+  }
+)
+```
+
+Returns `{ call_id, status, answered_by, duration_seconds, summary, outcome, transcript, recording_url, price_usd }`.
+A call reaching no one (busy / no answer) is free.
+
+## Create a Voice Agent
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/create_agent",
+  method="POST",
+  body={"name": "front-desk", "instructions": "You are a friendly dental receptionist. Book appointments and answer questions."}
+)
+```
+
+Returns `{ agent_id, phone_number, inbound }`. Requires wallet auth (SIWX).
+
+IMPORTANT: an inbound agent answers a caller only after you BOTH fund it (`top_up`) AND allowlist
+that caller (`allowlist_number`, or `allow_callers` at create time). Until both are done it
+silently rejects every inbound call.
+
+## Talk to the Builder
+
+Design or edit an agent in plain English. Omit `session_id` to start (the reply carries one);
+pass it back to continue. Replies are read for free with `build_view`.
+
+```
+agentcash.fetch(
+  url="https://call.kelam.sh/api/build",
+  method="POST",
+  body={"message": "Build me a receptionist for a dentist that books appointments and takes messages."}
+)
+```

--- a/skills/kelam-phone-calls/rules/getting-started.md
+++ b/skills/kelam-phone-calls/rules/getting-started.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check your wallet balance:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund your wallet** (USDC on Base) if needed:
+   - Redeem an invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` for Base/Solana deposit links + addresses
+
+4. **Discover the endpoints:**
+   ```bash
+   npx agentcash@latest discover https://call.kelam.sh
+   ```
+
+## Inbound agents need TWO things
+
+An agent you create with `inbound: true` answers a caller only when BOTH are true:
+
+1. **It is funded** -- buy prepaid credits with `top_up` (each answered inbound call spends one).
+2. **The caller is allowlisted** -- pass `allow_callers` at create time, or call `allowlist_number` later.
+
+Until both are done, the agent silently rejects every inbound call.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund your wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient errors) |
+| Inbound call not answered | Confirm the agent is funded (`top_up`) AND the caller is allowlisted |
+| Wrong endpoint | Use the exact paths from the Quick Reference in SKILL.md |
+
+## Pricing Reference
+
+| Endpoint | Price |
+|----------|-------|
+| place_call | $0.05 connect + $0.15/min (billed to the second, capped $2.00; unconnected = free) |
+| create_agent | $2.00 |
+| top_up | $0.40 per prepaid inbound call |
+| build | $0.40 per builder message |
+| call_status / list_agents / balance / allowlist_number / build_view | Free |


### PR DESCRIPTION
Adds a skill for **Kelam** (`call.kelam.sh`), an independent x402 service for real phone calls.

**What it does:** an agent can place a real outbound phone call to accomplish a task (book, confirm, chase, ask) and get back the transcript + outcome + extracted fields, or provision its own inbound/outbound voice agent under its wallet. Realistic voices, billed to the second in USDC via agentcash — no account, no API key. Live and discoverable on [x402scan](https://www.x402scan.com); browser demo at [kelam.sh](https://kelam.sh).

**Layout:** added under both `skills/kelam-phone-calls/` and `mcp/skills/kelam-phone-calls/` (SKILL.md + rules/getting-started.md) to match the existing structure.

Full disclosure: I'm affiliated with Kelam, and I realize this overlaps with the first-party `phone-calls` (StablePhone) skill — so I've left the README's Available Skills table for you to update however you prefer (a separate 'community' section, a rename, or not at all). Totally understand if you'd rather not list a third-party provider; happy to adjust to whatever convention you'd like, or you're welcome to close this. Either way, thanks for building the agentcash skills ecosystem.