### PR TITLE
Add base-gas skill: live and historical Base mainnet gas data

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npx skills add Merit-Systems/agentcash-skills/mcp --all --yes
 | [social-intelligence](skills/social-intelligence/) | Reddit search | Reddit |
 | [news-shopping](skills/news-shopping/) | News & product search | Serper |
 | [people-property](skills/people-property/) | People & property lookup | Whitepages |
+| [base-gas](skills/base-gas/) | Live & historical Base gas, cross-chain comparison, cheapest-hour scheduling | base-gas-x402 |
 
 These skills are also available in MCP mode (the [mcp](mcp/skills/) directory). Both directories contain the same skills — each skill has a `SKILL.md` and a `rules/` directory. Choose the mode that matches your environment.
 

--- a/mcp/skills/base-gas/SKILL.md
+++ b/mcp/skills/base-gas/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: base-gas
+description: |
+  Live and historical Base mainnet gas prices via x402, including cross-chain comparison and cheapest-hour scheduling.
+
+  USE FOR:
+  - Checking current gas prices on Base before sending a transaction
+  - Estimating transaction cost for a transfer, swap, NFT mint, or contract deploy
+  - Deciding whether gas is currently cheap or expensive
+  - Comparing gas costs across Base, OP Mainnet, Arbitrum, and Ethereum
+  - Finding the cheapest hour of day to transact on Base
+  - Budgeting gas spend for on-chain agent workloads
+
+  TRIGGERS:
+  - "gas price", "gas fees", "gwei", "base fee", "priority fee"
+  - "how much to send", "transaction cost", "cost to swap", "cost to mint"
+  - "is gas cheap right now", "should I transact now or wait"
+  - "compare gas", "cheapest chain", "which L2 is cheaper"
+  - "best time to transact", "cheapest hour", "schedule transaction"
+
+  Call `GET /health` first (free) before paying for history endpoints. Use `agentcash.fetch` for the paid routes.
+mcp:
+  - agentcash
+metadata:
+  version: 1
+---
+
+# Base Gas
+
+Live and historical Base mainnet gas data through x402-protected endpoints, served from `https://base-gas-x402-production.up.railway.app`.
+
+All values are read directly from the chain. Fees are returned in gwei.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Returns |
+|------|----------|-------|---------|
+| Current gas | `GET /gas` | $0.005 | Base fee, low/med/high priority tiers, cost estimate |
+| Compare chains | `GET /gas/compare` | $0.01 | Base, OP, Arbitrum, Ethereum ranked cheapest first |
+| Historical trend | `GET /gas/history` | $0.01 | Time series, min/max/avg/median, cheap-or-expensive verdict |
+| Cheapest hours | `GET /gas/cheapest-window` | $0.02 | Hourly averages ranked, cheapest hour, savings percent |
+| Data coverage | `GET /health` | **free** | How much history has been collected so far |
+
+See [rules/choosing-an-endpoint.md](rules/choosing-an-endpoint.md) for which route answers which question.
+
+## Current Gas
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas")
+```
+
+**Parameters:**
+- `gasLimit` (optional) - Gas units to price the estimate against. Defaults to 21000.
+
+Price the cost of a Uniswap swap instead of a plain transfer:
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas?gasLimit=180000")
+```
+
+**Common gas limits:**
+
+| Operation | gasLimit |
+|-----------|----------|
+| ETH transfer | 21000 |
+| ERC-20 transfer | 65000 |
+| NFT mint | 85000 |
+| Uniswap swap | 180000 |
+| Contract deploy | 1500000 |
+
+**Returns:** `baseFeePerGas`, `priorityFeePerGas` (low/medium/high), `gasPrice`, `estimatedTransferCost` (gwei and ETH), `blockNumber`, `fetchedAt`.
+
+## Compare Chains
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/compare")
+```
+
+**Parameters:**
+- `gasLimit` (optional) - Gas units to price each chain against. Defaults to 21000.
+
+**Returns:** `chains` ranked cheapest first, `cheapest`, `baseRank`, `baseVsEthereum` (a plain-language multiplier), and `unavailable` for any chain whose RPC did not respond.
+
+Chains that fail are reported rather than failing the whole request, so a partial comparison still returns useful data.
+
+## Historical Trend
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/history?hours=24")
+```
+
+**Parameters:**
+- `hours` (optional) - Lookback window, 1 to 168. Defaults to 24.
+
+**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, and `verdict`.
+
+The `verdict` field is the useful part: it reports whether the current price is `cheap`, `normal`, or `expensive` relative to the requested window. A raw RPC call cannot answer that, because it has no history to compare against.
+
+## Cheapest Hours
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/cheapest-window?hours=168")
+```
+
+**Parameters:**
+- `hours` (optional) - Lookback window used to compute hourly averages, 1 to 168. Defaults to 168 (7 days).
+
+**Returns:** `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc`, `priciestHourUtc`, and `savingsPercent`.
+
+Use this to schedule batch transactions, time a mint, or move recurring agent jobs into the cheap window.
+
+## Check Coverage First (free)
+
+Both history endpoints depend on samples collected over time. Check coverage before paying:
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/health")
+```
+
+**Returns:** `samples`, `hoursCovered`, `oldestSample`, `newestSample`, `sampleIntervalSeconds`, `retentionHours`.
+
+If `hoursCovered` is smaller than the window you need, the answer will be thin. Every paid response also carries a `coverage` object so the depth of the underlying data is always visible.
+
+## Workflows
+
+### Decide whether to transact now
+
+- [ ] Check the trend and verdict: `GET /gas/history?hours=24`
+- [ ] If `verdict` is `cheap`, proceed
+- [ ] If `expensive`, check when it gets cheaper: `GET /gas/cheapest-window`
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/history?hours=24")
+```
+
+### Price a specific operation
+
+- [ ] Pick the gasLimit for the operation type
+- [ ] Call `/gas` with that gasLimit
+- [ ] Read `estimatedTransferCost.eth`
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas?gasLimit=85000")
+```
+
+### Pick the cheapest chain
+
+- [ ] (Optional) Check coverage or balance
+- [ ] Compare chains at the relevant gasLimit
+- [ ] Route the transaction to `cheapest`
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/compare?gasLimit=180000")
+```
+
+### Schedule a batch job
+
+- [ ] Check history coverage: `GET /health` (free)
+- [ ] If coverage is at least 24 hours, call `/gas/cheapest-window`
+- [ ] Schedule the job for `cheapestHourUtc`
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/health")
+```
+
+```
+agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/cheapest-window?hours=168")
+```
+
+## Cost Optimization
+
+### Use `/gas` when:
+- You only need the current price
+- You are pricing a single known operation
+
+### Use `/gas/history` when:
+- The question is "is this high or low", not "what is it"
+- You need a trend or chart
+
+### Use `/gas/cheapest-window` when:
+- The work can wait
+- You are scheduling recurring or batch transactions
+
+### Efficient patterns
+
+1. **Check `/health` before history calls.** It is free and tells you whether the data is deep enough to be worth paying for.
+2. **One `/gas/compare` beats four `/gas` calls.** It reads all four chains in a single paid request.
+3. **Pass `gasLimit` instead of doing the math.** The estimate is returned already priced for the operation you care about.
+4. **Do not poll.** Base blocks are two seconds apart but gas moves slowly; sampling more than once a minute spends money for no new information.
+
+## Notes
+
+- Payment settles on Base mainnet (`eip155:8453`) in USDC via x402.
+- Prices are published in the endpoint's OpenAPI document at `/openapi.json` and are the source of truth if they ever differ from this table.
+- The service is open source: [github.com/memosr/base-gas-x402](https://github.com/memosr/base-gas-x402).

--- a/mcp/skills/base-gas/SKILL.md
+++ b/mcp/skills/base-gas/SKILL.md
@@ -41,7 +41,7 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 |------|----------|-------|---------|
 | Current gas | `GET /gas` | $0.005 | Base fee, low/med/high priority tiers, cost estimate |
 | Compare chains | `GET /gas/compare` | $0.01 | Base, OP, Arbitrum, Ethereum ranked cheapest first |
-| Historical trend | `GET /gas/history` | $0.01 | Time series, min/max/avg/median, cheap-or-expensive verdict |
+| Historical trend | `GET /gas/history` | $0.012 | Time series, min/max/avg/median, cheap-or-expensive verdict |
 | Cheapest hours | `GET /gas/cheapest-window` | $0.02 | Hourly averages ranked, cheapest hour, savings percent |
 | Data coverage | `GET /health` | **free** | How much history has been collected so far |
 
@@ -96,9 +96,11 @@ agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/history
 **Parameters:**
 - `hours` (optional) - Lookback window, 1 to 168. Defaults to 24.
 
-**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, and `verdict`.
+**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, `verdict`, `verdictNote`, and `spreadPercent`.
 
-The `verdict` field is the useful part: it reports whether the current price is `cheap`, `normal`, or `expensive` relative to the requested window. A raw RPC call cannot answer that, because it has no history to compare against.
+The `verdict` field is the useful part: `cheap`, `normal`, or `expensive` relative to the requested window, or `flat` when the window's spread is under 1%. A raw RPC call cannot answer this, because it has no history to compare against.
+
+`flat` is common on Base and is a real answer: gas is not moving, so there is nothing to wait for. Quote `verdictNote` rather than reinterpreting it.
 
 ## Cheapest Hours
 
@@ -109,9 +111,9 @@ agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/cheapes
 **Parameters:**
 - `hours` (optional) - Lookback window used to compute hourly averages, 1 to 168. Defaults to 168 (7 days).
 
-**Returns:** `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc`, `priciestHourUtc`, and `savingsPercent`.
+**Returns:** `hasDailyCycle`, a plain-language `recommendation`, `savingsPercent`, and `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc` and `priciestHourUtc`.
 
-Use this to schedule batch transactions, time a mint, or move recurring agent jobs into the cheap window.
+Check `hasDailyCycle` before using the ranking. When it is `false` the hours do not meaningfully differ and timing saves nothing; report `recommendation` instead of naming a cheapest hour.
 
 ## Check Coverage First (free)
 
@@ -130,8 +132,9 @@ If `hoursCovered` is smaller than the window you need, the answer will be thin. 
 ### Decide whether to transact now
 
 - [ ] Check the trend and verdict: `GET /gas/history?hours=24`
-- [ ] If `verdict` is `cheap`, proceed
-- [ ] If `expensive`, check when it gets cheaper: `GET /gas/cheapest-window`
+- [ ] If `verdict` is `flat`, proceed and tell the user there is nothing to wait for
+- [ ] If `cheap`, proceed
+- [ ] If `expensive`, check whether waiting actually helps: `GET /gas/cheapest-window`
 
 ```
 agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/history?hours=24")
@@ -161,7 +164,8 @@ agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/gas/compare
 
 - [ ] Check history coverage: `GET /health` (free)
 - [ ] If coverage is at least 24 hours, call `/gas/cheapest-window`
-- [ ] Schedule the job for `cheapestHourUtc`
+- [ ] If `hasDailyCycle` is `false`, report `recommendation` and run the job whenever
+- [ ] If `true`, schedule the job for `cheapestHourUtc` (convert from UTC)
 
 ```
 agentcash.fetch(url="https://base-gas-x402-production.up.railway.app/health")

--- a/mcp/skills/base-gas/rules/choosing-an-endpoint.md
+++ b/mcp/skills/base-gas/rules/choosing-an-endpoint.md
@@ -21,7 +21,7 @@ Four paid routes answer four different questions. Picking the wrong one either o
 
 ## Do not loop `/gas` to build history
 
-Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.01 replaces an unbounded number of `/gas` calls.
+Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.012 replaces an unbounded number of `/gas` calls.
 
 ## Do not loop `/gas` across chains
 
@@ -46,12 +46,21 @@ Every paid history response also embeds a `coverage` object, so the depth of the
 | `cheap` | Current price is in the bottom third of the window's range |
 | `normal` | Middle third |
 | `expensive` | Top third |
-| `flat` | The window showed no meaningful variation |
+| `flat` | The window's spread is under 1%, so the range carries no signal |
 
 The verdict is relative to the `hours` window requested. A price can be `cheap` against 24 hours and `expensive` against 7 days, so state the window when reporting it to the user.
 
+**`flat` is the common case on Base and it is a real answer, not a missing one.** Base sits on its fee floor for hours at a time. When the verdict is `flat`, do not tell the user gas is cheap and they should act now; tell them gas is not moving and there is nothing to wait for. The `verdictNote` field says this in plain language and `spreadPercent` gives the measured width of the window, so quote those rather than inventing an interpretation.
+
 ## Interpreting `cheapestHourUtc`
 
-Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+**Read `hasDailyCycle` first.** When it is `false`, the chain has no usable daily gas cycle in that window and `hourlyAverages` is not actionable, even though it is still returned. Report the `recommendation` field instead of naming a "cheapest hour", because the ranking in that case is ordering noise.
 
-`savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.
+When `hasDailyCycle` is `true`:
+
+- Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+- `savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.
+
+## Do not oversell a flat chain
+
+If the user is asking whether to wait for cheaper gas on Base, the honest answer is usually no. Say so. Recommending that someone delay a transaction to save a fraction of a percent of a fee that is already a rounding error wastes their time and costs them the call.

--- a/mcp/skills/base-gas/rules/choosing-an-endpoint.md
+++ b/mcp/skills/base-gas/rules/choosing-an-endpoint.md
@@ -1,0 +1,57 @@
+# Choosing an Endpoint
+
+Four paid routes answer four different questions. Picking the wrong one either overpays or returns data that does not answer the user's actual question.
+
+## Map the question to the route
+
+| The user is asking | Route | Why |
+|--------------------|-------|-----|
+| "What is gas right now?" | `/gas` | A single point-in-time reading |
+| "How much will this cost?" | `/gas` with `gasLimit` | The estimate comes back already priced for the operation |
+| "Is gas high or low?" | `/gas/history` | Requires a baseline to compare against |
+| "Should I send now or wait?" | `/gas/history` then `/gas/cheapest-window` | The verdict answers now; the window answers when |
+| "Which chain is cheapest?" | `/gas/compare` | Reads four chains in one paid call |
+| "Is bridging to Base worth it?" | `/gas/compare` | `baseVsEthereum` states the multiplier directly |
+| "When should I schedule this?" | `/gas/cheapest-window` | Hour-of-day ranking |
+| "Do you have enough data?" | `/health` | Free, no payment |
+
+## Do not substitute `/gas` for history
+
+`/gas` reports the current gas price. It cannot say whether that price is high or low, because a single reading has no context. If the user's question contains a comparison ("cheap", "high", "spike", "trend", "worth waiting"), the answer needs `/gas/history`.
+
+## Do not loop `/gas` to build history
+
+Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.01 replaces an unbounded number of `/gas` calls.
+
+## Do not loop `/gas` across chains
+
+`/gas` only covers Base. For multi-chain questions use `/gas/compare`: one call, four chains, $0.01.
+
+## Check coverage before paying for history
+
+`/health` is free and reports how many samples exist and how many hours they span. The history endpoints depend on that buffer.
+
+- Coverage under 1 hour: history is not yet meaningful. Use `/gas` instead.
+- Coverage under 24 hours: `/gas/history` works, but `/gas/cheapest-window` cannot rank a full day yet.
+- Coverage 24 hours or more: both history routes are meaningful.
+
+Every paid history response also embeds a `coverage` object, so the depth of the underlying data is visible after the fact as well.
+
+## Interpreting `verdict`
+
+`/gas/history` returns `verdict` as one of:
+
+| Value | Meaning |
+|-------|---------|
+| `cheap` | Current price is in the bottom third of the window's range |
+| `normal` | Middle third |
+| `expensive` | Top third |
+| `flat` | The window showed no meaningful variation |
+
+The verdict is relative to the `hours` window requested. A price can be `cheap` against 24 hours and `expensive` against 7 days, so state the window when reporting it to the user.
+
+## Interpreting `cheapestHourUtc`
+
+Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+
+`savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.

--- a/mcp/skills/base-gas/rules/getting-started.md
+++ b/mcp/skills/base-gas/rules/getting-started.md
@@ -1,0 +1,25 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash MCP:**
+   ```bash
+   npx agentcash@latest install --client claude-code -y
+   ```
+
+2. **Check wallet:**
+```mcp
+   agentcash.get_balance()
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `agentcash.redeem_invite(code="YOUR_CODE")`
+   - Or call `agentcash.list_accounts()` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "MCP tool not found" | Run install command, restart Claude Code |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |

--- a/skills/base-gas/SKILL.md
+++ b/skills/base-gas/SKILL.md
@@ -39,7 +39,7 @@ See [rules/getting-started.md](rules/getting-started.md) for installation and wa
 |------|----------|-------|---------|
 | Current gas | `GET /gas` | $0.005 | Base fee, low/med/high priority tiers, cost estimate |
 | Compare chains | `GET /gas/compare` | $0.01 | Base, OP, Arbitrum, Ethereum ranked cheapest first |
-| Historical trend | `GET /gas/history` | $0.01 | Time series, min/max/avg/median, cheap-or-expensive verdict |
+| Historical trend | `GET /gas/history` | $0.012 | Time series, min/max/avg/median, cheap-or-expensive verdict |
 | Cheapest hours | `GET /gas/cheapest-window` | $0.02 | Hourly averages ranked, cheapest hour, savings percent |
 | Data coverage | `GET /health` | **free** | How much history has been collected so far |
 
@@ -94,9 +94,11 @@ npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/
 **Parameters:**
 - `hours` (optional) - Lookback window, 1 to 168. Defaults to 24.
 
-**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, and `verdict`.
+**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, `verdict`, `verdictNote`, and `spreadPercent`.
 
-The `verdict` field is the useful part: it reports whether the current price is `cheap`, `normal`, or `expensive` relative to the requested window. A raw RPC call cannot answer that, because it has no history to compare against.
+The `verdict` field is the useful part: `cheap`, `normal`, or `expensive` relative to the requested window, or `flat` when the window's spread is under 1%. A raw RPC call cannot answer this, because it has no history to compare against.
+
+`flat` is common on Base and is a real answer: gas is not moving, so there is nothing to wait for. Quote `verdictNote` rather than reinterpreting it.
 
 ## Cheapest Hours
 
@@ -107,9 +109,9 @@ npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/
 **Parameters:**
 - `hours` (optional) - Lookback window used to compute hourly averages, 1 to 168. Defaults to 168 (7 days).
 
-**Returns:** `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc`, `priciestHourUtc`, and `savingsPercent`.
+**Returns:** `hasDailyCycle`, a plain-language `recommendation`, `savingsPercent`, and `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc` and `priciestHourUtc`.
 
-Use this to schedule batch transactions, time a mint, or move recurring agent jobs into the cheap window.
+Check `hasDailyCycle` before using the ranking. When it is `false` the hours do not meaningfully differ and timing saves nothing; report `recommendation` instead of naming a cheapest hour.
 
 ## Check Coverage First (free)
 
@@ -128,8 +130,9 @@ If `hoursCovered` is smaller than the window you need, the answer will be thin. 
 ### Decide whether to transact now
 
 - [ ] Check the trend and verdict: `GET /gas/history?hours=24`
-- [ ] If `verdict` is `cheap`, proceed
-- [ ] If `expensive`, check when it gets cheaper: `GET /gas/cheapest-window`
+- [ ] If `verdict` is `flat`, proceed and tell the user there is nothing to wait for
+- [ ] If `cheap`, proceed
+- [ ] If `expensive`, check whether waiting actually helps: `GET /gas/cheapest-window`
 
 ```bash
 npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/history?hours=24"
@@ -159,7 +162,8 @@ npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/
 
 - [ ] Check history coverage: `GET /health` (free)
 - [ ] If coverage is at least 24 hours, call `/gas/cheapest-window`
-- [ ] Schedule the job for `cheapestHourUtc`
+- [ ] If `hasDailyCycle` is `false`, report `recommendation` and run the job whenever
+- [ ] If `true`, schedule the job for `cheapestHourUtc` (convert from UTC)
 
 ```bash
 curl -s https://base-gas-x402-production.up.railway.app/health

--- a/skills/base-gas/SKILL.md
+++ b/skills/base-gas/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: base-gas
+description: |
+  Live and historical Base mainnet gas prices via x402, including cross-chain comparison and cheapest-hour scheduling.
+
+  USE FOR:
+  - Checking current gas prices on Base before sending a transaction
+  - Estimating transaction cost for a transfer, swap, NFT mint, or contract deploy
+  - Deciding whether gas is currently cheap or expensive
+  - Comparing gas costs across Base, OP Mainnet, Arbitrum, and Ethereum
+  - Finding the cheapest hour of day to transact on Base
+  - Budgeting gas spend for on-chain agent workloads
+
+  TRIGGERS:
+  - "gas price", "gas fees", "gwei", "base fee", "priority fee"
+  - "how much to send", "transaction cost", "cost to swap", "cost to mint"
+  - "is gas cheap right now", "should I transact now or wait"
+  - "compare gas", "cheapest chain", "which L2 is cheaper"
+  - "best time to transact", "cheapest hour", "schedule transaction"
+
+  Call `GET /health` first (free) before paying for history endpoints. Use `npx agentcash@latest fetch` for the paid routes.
+metadata:
+  version: 1
+---
+
+# Base Gas
+
+Live and historical Base mainnet gas data through x402-protected endpoints, served from `https://base-gas-x402-production.up.railway.app`.
+
+All values are read directly from the chain. Fees are returned in gwei.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Returns |
+|------|----------|-------|---------|
+| Current gas | `GET /gas` | $0.005 | Base fee, low/med/high priority tiers, cost estimate |
+| Compare chains | `GET /gas/compare` | $0.01 | Base, OP, Arbitrum, Ethereum ranked cheapest first |
+| Historical trend | `GET /gas/history` | $0.01 | Time series, min/max/avg/median, cheap-or-expensive verdict |
+| Cheapest hours | `GET /gas/cheapest-window` | $0.02 | Hourly averages ranked, cheapest hour, savings percent |
+| Data coverage | `GET /health` | **free** | How much history has been collected so far |
+
+See [rules/choosing-an-endpoint.md](rules/choosing-an-endpoint.md) for which route answers which question.
+
+## Current Gas
+
+```bash
+npx agentcash@latest fetch https://base-gas-x402-production.up.railway.app/gas
+```
+
+**Parameters:**
+- `gasLimit` (optional) - Gas units to price the estimate against. Defaults to 21000.
+
+Price the cost of a Uniswap swap instead of a plain transfer:
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas?gasLimit=180000"
+```
+
+**Common gas limits:**
+
+| Operation | gasLimit |
+|-----------|----------|
+| ETH transfer | 21000 |
+| ERC-20 transfer | 65000 |
+| NFT mint | 85000 |
+| Uniswap swap | 180000 |
+| Contract deploy | 1500000 |
+
+**Returns:** `baseFeePerGas`, `priorityFeePerGas` (low/medium/high), `gasPrice`, `estimatedTransferCost` (gwei and ETH), `blockNumber`, `fetchedAt`.
+
+## Compare Chains
+
+```bash
+npx agentcash@latest fetch https://base-gas-x402-production.up.railway.app/gas/compare
+```
+
+**Parameters:**
+- `gasLimit` (optional) - Gas units to price each chain against. Defaults to 21000.
+
+**Returns:** `chains` ranked cheapest first, `cheapest`, `baseRank`, `baseVsEthereum` (a plain-language multiplier), and `unavailable` for any chain whose RPC did not respond.
+
+Chains that fail are reported rather than failing the whole request, so a partial comparison still returns useful data.
+
+## Historical Trend
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/history?hours=24"
+```
+
+**Parameters:**
+- `hours` (optional) - Lookback window, 1 to 168. Defaults to 24.
+
+**Returns:** `samples` time series, `summary` (min, max, avg, median), `currentGasPrice`, and `verdict`.
+
+The `verdict` field is the useful part: it reports whether the current price is `cheap`, `normal`, or `expensive` relative to the requested window. A raw RPC call cannot answer that, because it has no history to compare against.
+
+## Cheapest Hours
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/cheapest-window?hours=168"
+```
+
+**Parameters:**
+- `hours` (optional) - Lookback window used to compute hourly averages, 1 to 168. Defaults to 168 (7 days).
+
+**Returns:** `hourlyAverages` bucketed by hour of day in UTC and ranked cheapest first, plus `cheapestHourUtc`, `priciestHourUtc`, and `savingsPercent`.
+
+Use this to schedule batch transactions, time a mint, or move recurring agent jobs into the cheap window.
+
+## Check Coverage First (free)
+
+Both history endpoints depend on samples collected over time. Check coverage before paying:
+
+```bash
+curl -s https://base-gas-x402-production.up.railway.app/health
+```
+
+**Returns:** `samples`, `hoursCovered`, `oldestSample`, `newestSample`, `sampleIntervalSeconds`, `retentionHours`.
+
+If `hoursCovered` is smaller than the window you need, the answer will be thin. Every paid response also carries a `coverage` object so the depth of the underlying data is always visible.
+
+## Workflows
+
+### Decide whether to transact now
+
+- [ ] Check the trend and verdict: `GET /gas/history?hours=24`
+- [ ] If `verdict` is `cheap`, proceed
+- [ ] If `expensive`, check when it gets cheaper: `GET /gas/cheapest-window`
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/history?hours=24"
+```
+
+### Price a specific operation
+
+- [ ] Pick the gasLimit for the operation type
+- [ ] Call `/gas` with that gasLimit
+- [ ] Read `estimatedTransferCost.eth`
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas?gasLimit=85000"
+```
+
+### Pick the cheapest chain
+
+- [ ] (Optional) Check coverage or balance
+- [ ] Compare chains at the relevant gasLimit
+- [ ] Route the transaction to `cheapest`
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/compare?gasLimit=180000"
+```
+
+### Schedule a batch job
+
+- [ ] Check history coverage: `GET /health` (free)
+- [ ] If coverage is at least 24 hours, call `/gas/cheapest-window`
+- [ ] Schedule the job for `cheapestHourUtc`
+
+```bash
+curl -s https://base-gas-x402-production.up.railway.app/health
+```
+
+```bash
+npx agentcash@latest fetch "https://base-gas-x402-production.up.railway.app/gas/cheapest-window?hours=168"
+```
+
+## Cost Optimization
+
+### Use `/gas` when:
+- You only need the current price
+- You are pricing a single known operation
+
+### Use `/gas/history` when:
+- The question is "is this high or low", not "what is it"
+- You need a trend or chart
+
+### Use `/gas/cheapest-window` when:
+- The work can wait
+- You are scheduling recurring or batch transactions
+
+### Efficient patterns
+
+1. **Check `/health` before history calls.** It is free and tells you whether the data is deep enough to be worth paying for.
+2. **One `/gas/compare` beats four `/gas` calls.** It reads all four chains in a single paid request.
+3. **Pass `gasLimit` instead of doing the math.** The estimate is returned already priced for the operation you care about.
+4. **Do not poll.** Base blocks are two seconds apart but gas moves slowly; sampling more than once a minute spends money for no new information.
+
+## Notes
+
+- Payment settles on Base mainnet (`eip155:8453`) in USDC via x402.
+- Prices are published in the endpoint's OpenAPI document at `/openapi.json` and are the source of truth if they ever differ from this table.
+- The service is open source: [github.com/memosr/base-gas-x402](https://github.com/memosr/base-gas-x402).

--- a/skills/base-gas/rules/choosing-an-endpoint.md
+++ b/skills/base-gas/rules/choosing-an-endpoint.md
@@ -21,7 +21,7 @@ Four paid routes answer four different questions. Picking the wrong one either o
 
 ## Do not loop `/gas` to build history
 
-Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.01 replaces an unbounded number of `/gas` calls.
+Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.012 replaces an unbounded number of `/gas` calls.
 
 ## Do not loop `/gas` across chains
 
@@ -46,12 +46,21 @@ Every paid history response also embeds a `coverage` object, so the depth of the
 | `cheap` | Current price is in the bottom third of the window's range |
 | `normal` | Middle third |
 | `expensive` | Top third |
-| `flat` | The window showed no meaningful variation |
+| `flat` | The window's spread is under 1%, so the range carries no signal |
 
 The verdict is relative to the `hours` window requested. A price can be `cheap` against 24 hours and `expensive` against 7 days, so state the window when reporting it to the user.
 
+**`flat` is the common case on Base and it is a real answer, not a missing one.** Base sits on its fee floor for hours at a time. When the verdict is `flat`, do not tell the user gas is cheap and they should act now; tell them gas is not moving and there is nothing to wait for. The `verdictNote` field says this in plain language and `spreadPercent` gives the measured width of the window, so quote those rather than inventing an interpretation.
+
 ## Interpreting `cheapestHourUtc`
 
-Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+**Read `hasDailyCycle` first.** When it is `false`, the chain has no usable daily gas cycle in that window and `hourlyAverages` is not actionable, even though it is still returned. Report the `recommendation` field instead of naming a "cheapest hour", because the ranking in that case is ordering noise.
 
-`savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.
+When `hasDailyCycle` is `true`:
+
+- Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+- `savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.
+
+## Do not oversell a flat chain
+
+If the user is asking whether to wait for cheaper gas on Base, the honest answer is usually no. Say so. Recommending that someone delay a transaction to save a fraction of a percent of a fee that is already a rounding error wastes their time and costs them the call.

--- a/skills/base-gas/rules/choosing-an-endpoint.md
+++ b/skills/base-gas/rules/choosing-an-endpoint.md
@@ -1,0 +1,57 @@
+# Choosing an Endpoint
+
+Four paid routes answer four different questions. Picking the wrong one either overpays or returns data that does not answer the user's actual question.
+
+## Map the question to the route
+
+| The user is asking | Route | Why |
+|--------------------|-------|-----|
+| "What is gas right now?" | `/gas` | A single point-in-time reading |
+| "How much will this cost?" | `/gas` with `gasLimit` | The estimate comes back already priced for the operation |
+| "Is gas high or low?" | `/gas/history` | Requires a baseline to compare against |
+| "Should I send now or wait?" | `/gas/history` then `/gas/cheapest-window` | The verdict answers now; the window answers when |
+| "Which chain is cheapest?" | `/gas/compare` | Reads four chains in one paid call |
+| "Is bridging to Base worth it?" | `/gas/compare` | `baseVsEthereum` states the multiplier directly |
+| "When should I schedule this?" | `/gas/cheapest-window` | Hour-of-day ranking |
+| "Do you have enough data?" | `/health` | Free, no payment |
+
+## Do not substitute `/gas` for history
+
+`/gas` reports the current gas price. It cannot say whether that price is high or low, because a single reading has no context. If the user's question contains a comparison ("cheap", "high", "spike", "trend", "worth waiting"), the answer needs `/gas/history`.
+
+## Do not loop `/gas` to build history
+
+Calling `/gas` repeatedly to assemble a time series costs $0.005 per sample and produces worse data than `/gas/history`, which is backed by continuous sampling that already happened. One `/gas/history` call at $0.01 replaces an unbounded number of `/gas` calls.
+
+## Do not loop `/gas` across chains
+
+`/gas` only covers Base. For multi-chain questions use `/gas/compare`: one call, four chains, $0.01.
+
+## Check coverage before paying for history
+
+`/health` is free and reports how many samples exist and how many hours they span. The history endpoints depend on that buffer.
+
+- Coverage under 1 hour: history is not yet meaningful. Use `/gas` instead.
+- Coverage under 24 hours: `/gas/history` works, but `/gas/cheapest-window` cannot rank a full day yet.
+- Coverage 24 hours or more: both history routes are meaningful.
+
+Every paid history response also embeds a `coverage` object, so the depth of the underlying data is visible after the fact as well.
+
+## Interpreting `verdict`
+
+`/gas/history` returns `verdict` as one of:
+
+| Value | Meaning |
+|-------|---------|
+| `cheap` | Current price is in the bottom third of the window's range |
+| `normal` | Middle third |
+| `expensive` | Top third |
+| `flat` | The window showed no meaningful variation |
+
+The verdict is relative to the `hours` window requested. A price can be `cheap` against 24 hours and `expensive` against 7 days, so state the window when reporting it to the user.
+
+## Interpreting `cheapestHourUtc`
+
+Hours are bucketed in **UTC**, not local time. Convert before telling the user when to transact, and say which timezone you converted to.
+
+`savingsPercent` compares the cheapest hour against the priciest hour in the window. It is the upper bound on savings from perfect timing, not a guarantee.

--- a/skills/base-gas/rules/getting-started.md
+++ b/skills/base-gas/rules/getting-started.md
@@ -1,0 +1,25 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |


### PR DESCRIPTION
Adds a `base-gas` skill in both CLI and MCP variants for the x402 origin `base-gas-x402-production.up.railway.app`.

## What it covers

| Route | Price | Returns |
|---|---|---|
| `GET /gas` | $0.005 | Base fee, priority tiers, cost estimate for any gasLimit |
| `GET /gas/compare` | $0.01 | Base, OP Mainnet, Arbitrum, Ethereum ranked cheapest first |
| `GET /gas/history` | $0.01 | Time series, summary stats, cheap/normal/expensive verdict |
| `GET /gas/cheapest-window` | $0.02 | Hour-of-day ranking, cheapest hour, savings percent |
| `GET /health` | free | History coverage, so agents can check before paying |

## Notes

- Passes `npx @agentcash/discovery@latest discover` with no warnings.
- The history routes answer questions a free RPC call cannot: whether the current price is high or low, and when the cheap hours are.
- `rules/choosing-an-endpoint.md` steers agents away from the expensive failure modes: looping `/gas` to build a time series, or calling `/gas` per chain instead of `/gas/compare`.
- `/health` is free and documented as a pre-check so agents do not pay for history before enough samples exist.

Source: https://github.com/memosr/base-gas-x402