### PR TITLE
Add base-transactions skill: Base fee decisions and finality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npx skills add Merit-Systems/agentcash-skills/mcp --all --yes
 | [social-intelligence](skills/social-intelligence/) | Reddit search | Reddit |
 | [news-shopping](skills/news-shopping/) | News & product search | Serper |
 | [people-property](skills/people-property/) | People & property lookup | Whitepages |
+| [base-transactions](skills/base-transactions/) | Base gas/fee decisions before a send, finality after | x402 terminal |
 
 These skills are also available in MCP mode (the [mcp](mcp/skills/) directory). Both directories contain the same skills — each skill has a `SKILL.md` and a `rules/` directory. Choose the mode that matches your environment.
 

--- a/mcp/skills/base-transactions/SKILL.md
+++ b/mcp/skills/base-transactions/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: base-transactions
+description: |
+  Decide when to send a Base mainnet transaction and whether a sent one is safe to act on, via x402.
+
+  USE FOR:
+  - Choosing max fee and priority fee before submitting a Base transaction
+  - Deciding whether to submit now or wait for a cheaper window
+  - Estimating the USD cost of an ETH transfer, USDC transfer, or x402 settlement
+  - Checking whether a submitted tx is safe (L1-attested) or finalized (L1-finalized)
+  - Deciding when a payment is irreversible enough to ship goods or credit an account
+
+  TRIGGERS:
+  - "gas", "gas price", "base fee", "priority fee", "EIP-1559"
+  - "should I send now", "wait for cheaper", "how much will this cost"
+  - "is it confirmed", "is it final", "safe to act on", "reorg"
+  - "before every send", "after submitting"
+
+  Use agentcash.fetch for these endpoints. $0.01 each, GET, no API key.
+mcp:
+  - agentcash
+metadata:
+  version: 2
+---
+
+# Base Transaction Decisions
+
+Two calls that bracket sending a transaction on Base mainnet: what fee to use
+before you submit, and whether the result is irreversible after you do.
+
+Both are computed live from Base RPC blocks. Neither is a modeled prediction —
+finality is read from the node's own `safe` and `finalized` block tags, and the
+fee is standard EIP-1559 arithmetic over the current base fee.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Returns |
+|------|----------|-------|---------|
+| Pre-send fee decision | `https://x402-mcp.onrender.com/base/tx-decision` | $0.01 | submit/wait, max fee + priority fee (gwei), USD cost |
+| Post-send finality | `https://x402-mcp.onrender.com/base/finality-check` | $0.01 | not_found / pending / unsafe / safe / finalized |
+| Full network briefing | `https://x402-mcp.onrender.com/swarm/products/d22bbf5f3c4b4666a6f80980c7bc7c50/purchase` | $0.05 | congestion, trend, ETH price, settle-now verdict |
+| Free preview of the briefing | `https://x402-mcp.onrender.com/pulse` | free | same shape, no payment |
+
+See [rules/when-to-use.md](rules/when-to-use.md) for choosing between them.
+
+## Before you send: tx-decision
+
+```bash
+agentcash.fetch(url="https://x402-mcp.onrender.com/base/tx-decision?gas=usdc&urgency=flexible")
+```
+
+**Parameters:**
+- `gas` — `eth` (21000), `usdc` (55000), `erc20`, `x402`, or an integer of gas units. Default `usdc`.
+- `urgency` — `now` (price it, always submit), `soon` (time-sensitive), `flexible` (wait for a cheap window). Default `flexible`.
+
+**Returns:**
+
+```json
+{
+  "submit": true,
+  "verdict": "SETTLE_NOW",
+  "why": "...",
+  "fee": {
+    "max_fee_per_gas_gwei": 0.011,
+    "max_priority_fee_per_gas_gwei": 0.001,
+    "current_base_fee_gwei": 0.005,
+    "next_base_fee_gwei": 0.005
+  },
+  "estimated_cost": { "gas": 55000, "eth": 3.3e-7, "usd": 0.00062 },
+  "recheck_in_s": 30,
+  "as_of_block": 49116340,
+  "as_of": "2026-08-02T04:00:00+00:00"
+}
+```
+
+`max_fee_per_gas_gwei` is `2 × base_fee + tip`, the standard headroom for one
+base-fee doubling. `estimated_cost` charges only `base + tip`, which is what you
+actually pay. When `submit` is false, `recheck_in_s` is how long to wait before
+asking again — it is a backoff, never a prediction that the price will drop.
+
+## After you send: finality-check
+
+```bash
+agentcash.fetch(url="https://x402-mcp.onrender.com/base/finality-check?tx=0xTX_HASH")
+```
+
+**Parameters:**
+- `tx` — 0x-prefixed 32-byte transaction hash (required)
+
+**Returns:**
+
+```json
+{
+  "tx": "0x7fe54ef1...",
+  "included": true,
+  "status": "finalized",
+  "tx_block": 49106777,
+  "confirmations": 9563,
+  "safe_block": 49116306,
+  "finalized_block": 49115873,
+  "latest_block": 49116340,
+  "why": "Block 49106777 is at or behind the chain's 'finalized' block ...",
+  "as_of": "2026-08-02T04:00:00+00:00"
+}
+```
+
+**Status ladder:**
+
+| status | Meaning | Reasonable action |
+|--------|---------|-------------------|
+| `not_found` | No such hash on Base mainnet | Do not assume dropped; it may not have propagated |
+| `pending` | Known, not yet in a block | Wait |
+| `unsafe` | In a block, sequencer-confirmed only | Fine for UX, not for releasing value |
+| `safe` | Block attested on L1 | Safe for most commerce |
+| `finalized` | Block finalized on L1 | Irreversible; safe to ship goods or credit an account |
+
+## Paying
+
+Both endpoints are x402: an unpaid GET returns `402` with a `PAYMENT-REQUIRED`
+header carrying the challenge. `agentcash.fetch` handles the signing and retry.
+
+- Network: Base mainnet (`eip155:8453`)
+- Asset: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
+- Amount: `10000` atomic units = $0.01
+- Settlement is gasless for the buyer (EIP-3009), so you need USDC, not ETH
+
+## What can go wrong
+
+- **Facilitator 502 mid-settle** — transient. No funds move and nothing is
+  delivered; retry the same request. There is nothing to reconcile.
+- **Staleness** — responses carry `as_of_block` and `as_of`. Base blocks land
+  every ~2s and the server caches its RPC snapshot for ~4s; treat anything more
+  than a few blocks old as history, not advice.
+- **422 with no charge** — a malformed parameter. Nothing was charged.
+
+Full operator documentation, including failure modes:
+<https://x402-mcp.onrender.com/llms.txt>

--- a/mcp/skills/base-transactions/rules/getting-started.md
+++ b/mcp/skills/base-transactions/rules/getting-started.md
@@ -1,0 +1,42 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash MCP:**
+   ```bash
+   npx agentcash@latest install --client claude-code -y
+   ```
+
+2. **Check wallet:**
+```mcp
+   agentcash.get_balance()
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `agentcash.redeem_invite(code="YOUR_CODE")`
+   - Or call `agentcash.list_accounts()` to get Base or Solana deposit links and wallet addresses
+
+   These endpoints settle on **Base mainnet in USDC**. Settlement is gasless for
+   the buyer (EIP-3009), so a USDC balance is enough — no ETH required.
+
+## Check the price without paying
+
+An unpaid request returns the challenge, so you can confirm the price and terms
+before spending anything:
+
+```bash
+curl -i "https://x402-mcp.onrender.com/base/tx-decision"
+```
+
+Expect `402` with a `PAYMENT-REQUIRED` header. Decoding it shows network
+`eip155:8453`, USDC, and `10000` atomic units ($0.01).
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "MCP tool not found" | Run install command, restart Claude Code |
+| "Insufficient balance" | Fund wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient facilitator errors are safe to retry — nothing settles on a failed attempt) |
+| `422` response | A malformed parameter; nothing was charged |
+| Stale-looking numbers | Check `as_of_block` in the response; the snapshot is cached ~4s |

--- a/mcp/skills/base-transactions/rules/when-to-use.md
+++ b/mcp/skills/base-transactions/rules/when-to-use.md
@@ -1,0 +1,39 @@
+# Choosing between the endpoints
+
+## tx-decision vs. free RPC
+
+`eth_feeHistory` is free and gives you raw numbers. This endpoint gives you the
+decision: EIP-1559 sizing with headroom, a submit-or-wait verdict against the
+current window, the USD cost for the operation you are actually doing, and a
+backoff interval. If your agent already has fee logic it trusts, use the free
+RPC — this is for loops that would otherwise hardcode a gas price.
+
+Call it **before every send** when your agent submits transactions in a loop.
+One call per transaction, not one per session: the answer changes with the
+block.
+
+## finality-check vs. counting confirmations
+
+Counting confirmations is a heuristic. This reads Base's own `safe` and
+`finalized` block tags, which reflect what L1 has actually attested to and
+finalized — a different question from "how many blocks since".
+
+Call it **after submitting**, before you do something you cannot undo: releasing
+goods, crediting an account, marking an invoice paid. `safe` is enough for most
+commerce; wait for `finalized` when reversal would be expensive.
+
+## The Pulse briefing
+
+The $0.05 composite is a full market briefing — congestion, trend, ETH price,
+settlement costs across operation types, one settle-now verdict. It answers
+"what is the network doing right now", not "what should this transaction do".
+
+Use it for a periodic check (a morning report, a dashboard refresh), not in a
+per-transaction loop. `https://x402-mcp.onrender.com/pulse` is a free preview of
+the same shape, so try that before paying for the composite.
+
+## Cost sanity
+
+At $0.01 per call, an agent submitting 100 transactions a day spends $1/day on
+tx-decision. If your transactions are worth less than a few cents each, the
+decision costs more than the fee it optimizes — go with the free RPC.

--- a/skills/base-transactions/SKILL.md
+++ b/skills/base-transactions/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: base-transactions
+description: |
+  Decide when to send a Base mainnet transaction and whether a sent one is safe to act on, via x402.
+
+  USE FOR:
+  - Choosing max fee and priority fee before submitting a Base transaction
+  - Deciding whether to submit now or wait for a cheaper window
+  - Estimating the USD cost of an ETH transfer, USDC transfer, or x402 settlement
+  - Checking whether a submitted tx is safe (L1-attested) or finalized (L1-finalized)
+  - Deciding when a payment is irreversible enough to ship goods or credit an account
+
+  TRIGGERS:
+  - "gas", "gas price", "base fee", "priority fee", "EIP-1559"
+  - "should I send now", "wait for cheaper", "how much will this cost"
+  - "is it confirmed", "is it final", "safe to act on", "reorg"
+  - "before every send", "after submitting"
+
+  Use `npx agentcash@latest fetch` for these endpoints. $0.01 each, GET, no API key.
+metadata:
+  version: 2
+---
+
+# Base Transaction Decisions
+
+Two calls that bracket sending a transaction on Base mainnet: what fee to use
+before you submit, and whether the result is irreversible after you do.
+
+Both are computed live from Base RPC blocks. Neither is a modeled prediction —
+finality is read from the node's own `safe` and `finalized` block tags, and the
+fee is standard EIP-1559 arithmetic over the current base fee.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Returns |
+|------|----------|-------|---------|
+| Pre-send fee decision | `https://x402-mcp.onrender.com/base/tx-decision` | $0.01 | submit/wait, max fee + priority fee (gwei), USD cost |
+| Post-send finality | `https://x402-mcp.onrender.com/base/finality-check` | $0.01 | not_found / pending / unsafe / safe / finalized |
+| Full network briefing | `https://x402-mcp.onrender.com/swarm/products/d22bbf5f3c4b4666a6f80980c7bc7c50/purchase` | $0.05 | congestion, trend, ETH price, settle-now verdict |
+| Free preview of the briefing | `https://x402-mcp.onrender.com/pulse` | free | same shape, no payment |
+
+See [rules/when-to-use.md](rules/when-to-use.md) for choosing between them.
+
+## Before you send: tx-decision
+
+```bash
+npx agentcash@latest fetch "https://x402-mcp.onrender.com/base/tx-decision?gas=usdc&urgency=flexible"
+```
+
+**Parameters:**
+- `gas` — `eth` (21000), `usdc` (55000), `erc20`, `x402`, or an integer of gas units. Default `usdc`.
+- `urgency` — `now` (price it, always submit), `soon` (time-sensitive), `flexible` (wait for a cheap window). Default `flexible`.
+
+**Returns:**
+
+```json
+{
+  "submit": true,
+  "verdict": "SETTLE_NOW",
+  "why": "...",
+  "fee": {
+    "max_fee_per_gas_gwei": 0.011,
+    "max_priority_fee_per_gas_gwei": 0.001,
+    "current_base_fee_gwei": 0.005,
+    "next_base_fee_gwei": 0.005
+  },
+  "estimated_cost": { "gas": 55000, "eth": 3.3e-7, "usd": 0.00062 },
+  "recheck_in_s": 30,
+  "as_of_block": 49116340,
+  "as_of": "2026-08-02T04:00:00+00:00"
+}
+```
+
+`max_fee_per_gas_gwei` is `2 × base_fee + tip`, the standard headroom for one
+base-fee doubling. `estimated_cost` charges only `base + tip`, which is what you
+actually pay. When `submit` is false, `recheck_in_s` is how long to wait before
+asking again — it is a backoff, never a prediction that the price will drop.
+
+## After you send: finality-check
+
+```bash
+npx agentcash@latest fetch "https://x402-mcp.onrender.com/base/finality-check?tx=0xTX_HASH"
+```
+
+**Parameters:**
+- `tx` — 0x-prefixed 32-byte transaction hash (required)
+
+**Returns:**
+
+```json
+{
+  "tx": "0x7fe54ef1...",
+  "included": true,
+  "status": "finalized",
+  "tx_block": 49106777,
+  "confirmations": 9563,
+  "safe_block": 49116306,
+  "finalized_block": 49115873,
+  "latest_block": 49116340,
+  "why": "Block 49106777 is at or behind the chain's 'finalized' block ...",
+  "as_of": "2026-08-02T04:00:00+00:00"
+}
+```
+
+**Status ladder:**
+
+| status | Meaning | Reasonable action |
+|--------|---------|-------------------|
+| `not_found` | No such hash on Base mainnet | Do not assume dropped; it may not have propagated |
+| `pending` | Known, not yet in a block | Wait |
+| `unsafe` | In a block, sequencer-confirmed only | Fine for UX, not for releasing value |
+| `safe` | Block attested on L1 | Safe for most commerce |
+| `finalized` | Block finalized on L1 | Irreversible; safe to ship goods or credit an account |
+
+## Paying
+
+Both endpoints are x402: an unpaid GET returns `402` with a `PAYMENT-REQUIRED`
+header carrying the challenge. `agentcash fetch` handles the signing and retry.
+
+- Network: Base mainnet (`eip155:8453`)
+- Asset: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
+- Amount: `10000` atomic units = $0.01
+- Settlement is gasless for the buyer (EIP-3009), so you need USDC, not ETH
+
+## What can go wrong
+
+- **Facilitator 502 mid-settle** — transient. No funds move and nothing is
+  delivered; retry the same request. There is nothing to reconcile.
+- **Staleness** — responses carry `as_of_block` and `as_of`. Base blocks land
+  every ~2s and the server caches its RPC snapshot for ~4s; treat anything more
+  than a few blocks old as history, not advice.
+- **422 with no charge** — a malformed parameter. Nothing was charged.
+
+Full operator documentation, including failure modes:
+<https://x402-mcp.onrender.com/llms.txt>

--- a/skills/base-transactions/rules/getting-started.md
+++ b/skills/base-transactions/rules/getting-started.md
@@ -1,0 +1,42 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+   These endpoints settle on **Base mainnet in USDC**. Settlement is gasless for
+   the buyer (EIP-3009), so a USDC balance is enough — no ETH required.
+
+## Check the price without paying
+
+An unpaid request returns the challenge, so you can confirm the price and terms
+before spending anything:
+
+```bash
+curl -i "https://x402-mcp.onrender.com/base/tx-decision"
+```
+
+Expect `402` with a `PAYMENT-REQUIRED` header. Decoding it shows network
+`eip155:8453`, USDC, and `10000` atomic units ($0.01).
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC on Base |
+| "Payment failed" | Check balance, retry (transient facilitator errors are safe to retry — nothing settles on a failed attempt) |
+| `422` response | A malformed parameter; nothing was charged |
+| Stale-looking numbers | Check `as_of_block` in the response; the snapshot is cached ~4s |

--- a/skills/base-transactions/rules/when-to-use.md
+++ b/skills/base-transactions/rules/when-to-use.md
@@ -1,0 +1,39 @@
+# Choosing between the endpoints
+
+## tx-decision vs. free RPC
+
+`eth_feeHistory` is free and gives you raw numbers. This endpoint gives you the
+decision: EIP-1559 sizing with headroom, a submit-or-wait verdict against the
+current window, the USD cost for the operation you are actually doing, and a
+backoff interval. If your agent already has fee logic it trusts, use the free
+RPC — this is for loops that would otherwise hardcode a gas price.
+
+Call it **before every send** when your agent submits transactions in a loop.
+One call per transaction, not one per session: the answer changes with the
+block.
+
+## finality-check vs. counting confirmations
+
+Counting confirmations is a heuristic. This reads Base's own `safe` and
+`finalized` block tags, which reflect what L1 has actually attested to and
+finalized — a different question from "how many blocks since".
+
+Call it **after submitting**, before you do something you cannot undo: releasing
+goods, crediting an account, marking an invoice paid. `safe` is enough for most
+commerce; wait for `finalized` when reversal would be expensive.
+
+## The Pulse briefing
+
+The $0.05 composite is a full market briefing — congestion, trend, ETH price,
+settlement costs across operation types, one settle-now verdict. It answers
+"what is the network doing right now", not "what should this transaction do".
+
+Use it for a periodic check (a morning report, a dashboard refresh), not in a
+per-transaction loop. `https://x402-mcp.onrender.com/pulse` is a free preview of
+the same shape, so try that before paying for the composite.
+
+## Cost sanity
+
+At $0.01 per call, an agent submitting 100 transactions a day spends $1/day on
+tx-decision. If your transactions are worth less than a few cents each, the
+decision costs more than the fee it optimizes — go with the free RPC.


### PR DESCRIPTION
Adds a `base-transactions` skill covering two $0.01 x402 endpoints that bracket sending a transaction on Base mainnet:

- **`/base/tx-decision`** — before you send: submit-or-wait, `max_fee_per_gas` and priority fee in gwei (EIP-1559), and the USD cost for an ETH transfer, USDC transfer, or x402 settlement.
- **`/base/finality-check`** — after you send: classifies a tx hash as `not_found` / `pending` / `unsafe` / `safe` / `finalized`, read from the node's own `safe` and `finalized` block tags rather than modeled from a confirmation count.

Follows the existing layout: `skills/` for CLI mode, `mcp/skills/` for MCP mode, `rules/getting-started.md` in both, plus a `when-to-use.md`.

**Disclosure:** I operate these endpoints. Every skill in the repo today points at Merit-operated infrastructure (`stableenrich.dev` and friends), so this would be the first pointing at an independent third-party API — if you'd rather keep the set to your own endpoints, say so and I'll close this without argument. I'd also rather hear that than have it sit open.

**On the obvious objection** — `eth_feeHistory` is free, and `when-to-use.md` says so in the skill itself, including the break-even: at $0.01/call an agent submitting 100 txs/day spends $1/day, so if the transactions are worth cents the decision costs more than the fee it optimizes. The skill is aimed at loops that would otherwise hardcode a gas price, and at the finality question, which confirmation-counting answers badly.

**Traction, honestly:** small. Registered on x402scan today (`server/f9c7e039-c9b9-44ca-85ca-f0903884f401`, 9 resources, 4 priced); their explorer attributes 10 transactions / $0.90 / 3 buyers to the receive address over 30 days, of which two are genuine external wallets and the rest are my own indexing settles. I'm not going to dress that up as demand.

**Verifiable without paying anything:**

```bash
curl -i "https://x402-mcp.onrender.com/base/tx-decision"
```

402 with a `PAYMENT-REQUIRED` header: `eip155:8453`, USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, `10000` atomic units. Discovery docs at `/openapi.json` (with `x-payment-info`), `/.well-known/x402`, and `/llms.txt`; `npx @agentcash/discovery x402-mcp.onrender.com` passes clean.

Every number in the skill was checked against the running service before opening this — the gas presets, the fee arithmetic in the example, and the response shapes.