### PR TITLE
feat: add web-verification skill (ScrapeCheck)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add Merit-Systems/agentcash-skills/mcp --all --yes
 | [phone-calls](skills/phone-calls/) | AI phone calls, buy phone numbers | StablePhone |
 | [data-enrichment](skills/data-enrichment/) | Person, company profiles; email verification | FullEnrich, PDL, CompanyEnrich, Clado, Hunter, Minerva |
 | [web-research](skills/web-research/) | Web search & scraping | Exa, Firecrawl |
+| [web-verification](skills/web-verification/) | Verify a held web value against its live source page; signed offline-verifiable verdicts | ScrapeCheck |
 | [local-search](skills/local-search/) | Places & business info | Google Maps |
 | [social-intelligence](skills/social-intelligence/) | Reddit search | Reddit |
 | [news-shopping](skills/news-shopping/) | News & product search | Serper |

--- a/mcp/skills/web-verification/SKILL.md
+++ b/mcp/skills/web-verification/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: web-verification
+description: |
+  Verify a web value you already hold against its live source page using
+  ScrapeCheck's x402-protected API. Not retrieval: it checks a value, it
+  does not find data. Returns a signed pass/fail/unverifiable verdict
+  anyone can verify offline.
+
+  USE FOR:
+  - Checking a scraped or purchased value is on its source page right now
+  - Validating another tool's output (search result, scraper, upstream API)
+  - Confirming a price, title, or availability before acting on it
+  - Producing signed, offline-verifiable evidence of what a page said
+  - Cheap presence screening before a full check
+
+  TRIGGERS:
+  - "verify", "double-check", "confirm this is on the page"
+  - "is this price right", "is this still listed", "still in stock"
+  - "check the scraper's output", "validate this data"
+  - "signed verdict", "proof", "evidence it was on the page"
+
+  Use the agentcash MCP fetch tool against scrapecheck.fly.dev. Full
+  verification answers "is this the right value"; presence only answers
+  "does it appear at all" and never returns pass.
+metadata:
+  version: 1
+---
+
+# Web Verification with ScrapeCheck
+
+Check whether a value you did not fetch yourself is actually on the page
+it came from. ScrapeCheck independently re-fetches the source and returns
+an ed25519-signed pass/fail/unverifiable verdict. A claim is never
+certified unless the re-fetched page contains it, and anything
+unconfirmed is unverifiable — never converted to a pass.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation
+and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Best For |
+|------|----------|-------|----------|
+| Full verification | `https://scrapecheck.fly.dev/verify` | $0.01 | Is this value on the page AND the answer to what was asked |
+| Presence screen | `https://scrapecheck.fly.dev/verify-presence` | $0.002 | Does the value appear at all (never returns pass) |
+| Public key | `GET https://scrapecheck.fly.dev/pubkey` | Free | Verify signatures offline |
+| Issuance check | `GET https://scrapecheck.fly.dev/verdicts/{verdict_id}` | Free | Confirm a verdict_id was really issued |
+
+First 100 checks per client are free: send header
+`X-Use-Free-Allowance: yes` with no payment. Past the allowance, the
+x402 payment is the credential — no account, no API key.
+
+## When to Use What
+
+| Scenario | Tool |
+|----------|------|
+| You need to FIND data | A search/scraping skill, then verify the result here |
+| You hold a value and are about to act on it | `/verify` |
+| Cheap screen across many rows first | `/verify-presence`, then `/verify` the survivors |
+| The page is JS-only/client-rendered | Verdict will be unverifiable by design — ScrapeCheck never guesses |
+
+## Full Verification
+
+```mcp
+agentcash.fetch(
+  url="https://scrapecheck.fly.dev/verify",
+  method="POST",
+  body={
+    "url": "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
+    "claim": { "price": "£51.77" },
+    "asked": "get the current price of A Light in the Attic"
+  }
+)
+```
+
+Returns a signed verdict: `verdict` (pass | fail | unverifiable),
+`confidence`, `reasons`, `evidence` (re-fetch excerpt + timestamp),
+`verdict_id`, `key_id`, `source_hash`, `signature`.
+
+## Presence Screen
+
+```mcp
+agentcash.fetch(
+  url="https://scrapecheck.fly.dev/verify-presence",
+  method="POST",
+  body={
+    "url": "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
+    "claim": { "price": "£51.77" },
+    "asked": "context only"
+  }
+)
+```
+
+Presence confirms the value APPEARS on the page, not that it answers the
+question — a was-price, another variant's price, or a shipping cost can
+all satisfy presence. Positive verdict is `present`, never `pass`.
+
+## Verify a Verdict Offline
+
+Every verdict is ed25519-signed over canonical sorted-key JSON of every
+field except `signature`. Open verifier (MIT, zero dependencies) with a
+real example:
+https://github.com/FieldmodeLLC/scrapecheck-mcp#verify-a-verdict-yourself-offline
+
+You do not have to trust ScrapeCheck at runtime to rely on its output.
+
+## Scope
+
+Server-rendered public pages only. JS-only content returns unverifiable
+rather than a guess. Live verdict mix including fails and unverifiables:
+https://scrapecheck.fly.dev/stats

--- a/mcp/skills/web-verification/rules/getting-started.md
+++ b/mcp/skills/web-verification/rules/getting-started.md
@@ -1,0 +1,35 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+4. **Or start free:** the first 100 checks per client are free — send
+   header `X-Use-Free-Allowance: yes` with no payment:
+   ```bash
+   npx agentcash@latest fetch https://scrapecheck.fly.dev/verify -m POST \
+     -H "X-Use-Free-Allowance: yes" -b '{ "url": "...", "claim": { "price": "..." }, "asked": "..." }'
+   ```
+   Past the allowance, calls pay $0.01 (verify) / $0.002 (presence) in
+   USDC via x402 — no account, no API key.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC, or use the free-allowance header |
+| Verdict is `unverifiable` | The page is JS-only or the claim could not be confirmed — this is a real answer, never converted to a pass |
+| 400 response | Body must be `{ url, claim: {field: value}, asked }` — all three required |

--- a/skills/web-verification/SKILL.md
+++ b/skills/web-verification/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: web-verification
+description: |
+  Verify a web value you already hold against its live source page using
+  ScrapeCheck's x402-protected API. Not retrieval: it checks a value, it
+  does not find data. Returns a signed pass/fail/unverifiable verdict
+  anyone can verify offline.
+
+  USE FOR:
+  - Checking a scraped or purchased value is on its source page right now
+  - Validating another tool's output (search result, scraper, upstream API)
+  - Confirming a price, title, or availability before acting on it
+  - Producing signed, offline-verifiable evidence of what a page said
+  - Cheap presence screening before a full check
+
+  TRIGGERS:
+  - "verify", "double-check", "confirm this is on the page"
+  - "is this price right", "is this still listed", "still in stock"
+  - "check the scraper's output", "validate this data"
+  - "signed verdict", "proof", "evidence it was on the page"
+
+  Use `npx agentcash@latest fetch` against scrapecheck.fly.dev. Full
+  verification answers "is this the right value"; presence only answers
+  "does it appear at all" and never returns pass.
+metadata:
+  version: 1
+---
+
+# Web Verification with ScrapeCheck
+
+Check whether a value you did not fetch yourself is actually on the page
+it came from. ScrapeCheck independently re-fetches the source and returns
+an ed25519-signed pass/fail/unverifiable verdict. A claim is never
+certified unless the re-fetched page contains it, and anything
+unconfirmed is unverifiable — never converted to a pass.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation
+and wallet setup.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Best For |
+|------|----------|-------|----------|
+| Full verification | `https://scrapecheck.fly.dev/verify` | $0.01 | Is this value on the page AND the answer to what was asked |
+| Presence screen | `https://scrapecheck.fly.dev/verify-presence` | $0.002 | Does the value appear at all (never returns pass) |
+| Public key | `GET https://scrapecheck.fly.dev/pubkey` | Free | Verify signatures offline |
+| Issuance check | `GET https://scrapecheck.fly.dev/verdicts/{verdict_id}` | Free | Confirm a verdict_id was really issued |
+
+First 100 checks per client are free: send header
+`X-Use-Free-Allowance: yes` with no payment. Past the allowance, the
+x402 payment is the credential — no account, no API key.
+
+## When to Use What
+
+| Scenario | Tool |
+|----------|------|
+| You need to FIND data | A search/scraping skill, then verify the result here |
+| You hold a value and are about to act on it | `/verify` |
+| Cheap screen across many rows first | `/verify-presence`, then `/verify` the survivors |
+| The page is JS-only/client-rendered | Verdict will be unverifiable by design — ScrapeCheck never guesses |
+
+## Full Verification
+
+```bash
+npx agentcash@latest fetch https://scrapecheck.fly.dev/verify -m POST -b '{
+  "url": "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
+  "claim": { "price": "£51.77" },
+  "asked": "get the current price of A Light in the Attic"
+}'
+```
+
+Returns a signed verdict: `verdict` (pass | fail | unverifiable),
+`confidence`, `reasons`, `evidence` (re-fetch excerpt + timestamp),
+`verdict_id`, `key_id`, `source_hash`, `signature`.
+
+## Presence Screen
+
+```bash
+npx agentcash@latest fetch https://scrapecheck.fly.dev/verify-presence -m POST -b '{
+  "url": "https://books.toscrape.com/catalogue/a-light-in-the-attic_1000/index.html",
+  "claim": { "price": "£51.77" },
+  "asked": "context only"
+}'
+```
+
+Presence confirms the value APPEARS on the page, not that it answers the
+question — a was-price, another variant's price, or a shipping cost can
+all satisfy presence. Positive verdict is `present`, never `pass`.
+
+## Verify a Verdict Offline
+
+Every verdict is ed25519-signed over canonical sorted-key JSON of every
+field except `signature`. Open verifier (MIT, zero dependencies) with a
+real example:
+https://github.com/FieldmodeLLC/scrapecheck-mcp#verify-a-verdict-yourself-offline
+
+You do not have to trust ScrapeCheck at runtime to rely on its output.
+
+## Scope
+
+Server-rendered public pages only. JS-only content returns unverifiable
+rather than a guess. Live verdict mix including fails and unverifiables:
+https://scrapecheck.fly.dev/stats

--- a/skills/web-verification/rules/getting-started.md
+++ b/skills/web-verification/rules/getting-started.md
@@ -1,0 +1,35 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+4. **Or start free:** the first 100 checks per client are free — send
+   header `X-Use-Free-Allowance: yes` with no payment:
+   ```bash
+   npx agentcash@latest fetch https://scrapecheck.fly.dev/verify -m POST \
+     -H "X-Use-Free-Allowance: yes" -b '{ "url": "...", "claim": { "price": "..." }, "asked": "..." }'
+   ```
+   Past the allowance, calls pay $0.01 (verify) / $0.002 (presence) in
+   USDC via x402 — no account, no API key.
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC, or use the free-allowance header |
+| Verdict is `unverifiable` | The page is JS-only or the claim could not be confirmed — this is a real answer, never converted to a pass |
+| 400 response | Body must be `{ url, claim: {field: value}, asked }` — all three required |


### PR DESCRIPTION
Adds a web-verification skill in both modes (skills/ and mcp/skills/), following the web-research skill's structure (frontmatter with USE FOR and TRIGGERS, Quick Reference table, worked examples, rules/).

What it adds for agentcash users: the missing second half of every retrieval workflow. Your catalog already finds and scrapes (Exa, Firecrawl); this skill checks a value the agent already holds against its live source page and returns an ed25519-signed pass/fail/unverifiable verdict that verifies offline. The agent doesn't have to trust ScrapeCheck at runtime to rely on the answer. Natural pairing: Exa or Firecrawl retrieves, ScrapeCheck confirms, the agent acts.

Endpoints are direct x402 (USDC on Base), no API key, no signup; npx agentcash@latest fetch works against them today. First 100 checks per client are free via the X-Use-Free-Allowance: yes header (both modes' getting-started show it), so trying the skill costs nothing.

Scope is stated in the skill the way we state it everywhere: server-rendered pages; JS-only content returns unverifiable rather than a guess, and presence-tier positives are present, never pass.

Happy to adjust structure or copy to your conventions. Contact: sales@fieldmodesolutions.com.
