### PR TITLE
Add technographics skill (Hosaka) — DNS-proven vendor stack from a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx skills add Merit-Systems/agentcash-skills/mcp --all --yes
 | [email](skills/email/) | Send emails, forwarding inboxes, custom subdomains | StableEmail |
 | [phone-calls](skills/phone-calls/) | AI phone calls, buy phone numbers | StablePhone |
 | [data-enrichment](skills/data-enrichment/) | Person, company profiles; email verification | FullEnrich, PDL, CompanyEnrich, Clado, Hunter, Minerva |
+| [technographics](skills/technographics/) | DNS-proven vendor stack from a domain | Hosaka |
 | [web-research](skills/web-research/) | Web search & scraping | Exa, Firecrawl |
 | [local-search](skills/local-search/) | Places & business info | Google Maps |
 | [social-intelligence](skills/social-intelligence/) | Reddit search | Reddit |

--- a/mcp/skills/data-enrichment/SKILL.md
+++ b/mcp/skills/data-enrichment/SKILL.md
@@ -62,6 +62,8 @@ Before any stableenrich.dev call:
 
 For social media creators, use **stablesocial.dev** — influencer endpoints are not on stableenrich.dev.
 
+For the third-party tools a company runs, proven from its own DNS, use the `technographics` skill. CompanyEnrich returns industry, size and funding; it does not return the software a company uses.
+
 ## Workflows
 
 ### Standard Enrichment

--- a/mcp/skills/technographics/SKILL.md
+++ b/mcp/skills/technographics/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: technographics
+description: |
+  Find the third-party tools a company runs, from its domain alone, using x402-protected APIs at hosaka-agents.vercel.app. Every vendor comes back with the DNS record or loaded script that proves it, so the answer is checkable rather than asserted.
+
+  USE FOR:
+  - What software, tools or vendors a company uses
+  - Technology stack and technographics from a domain
+  - Company facts when you have a domain but no LinkedIn URL or email
+  - Public contacts, employees or decision makers at a domain
+
+  DO NOT USE FOR:
+  - Industry, headcount or funding — that is CompanyEnrich in data-enrichment
+  - Enriching a known person from a LinkedIn URL or email — that is PDL or FullEnrich in data-enrichment, and they are cheaper at that job
+
+  TRIGGERS:
+  - "tech stack", "technographics", "what tools", "what software"
+  - "vendors", "what is this company built with", "who runs this domain"
+  - "what does [company] use", "decision makers at"
+metadata:
+  version: 1.0
+---
+
+# Technographics with x402 APIs
+
+Use the agentcash CLI to access Hosaka at hosaka-agents.vercel.app. Domain in,
+proven vendors out.
+
+Complementary to `data-enrichment`: CompanyEnrich returns industry, size and
+funding; these endpoints return the tools a company actually runs. PDL and
+FullEnrich need a LinkedIn URL or an email before they answer anything, so when
+all you hold is a domain, they cannot help and this can.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Mandatory workflow
+
+Before any hosaka-agents.vercel.app call:
+
+1. `npx agentcash@latest discover https://hosaka-agents.vercel.app`
+2. `npx agentcash@latest check <endpoint-url>` — confirm request fields and pricing
+3. `npx agentcash@latest fetch` with the schema from step 2
+
+ALWAYS use `npx agentcash@latest fetch` for these endpoints — never curl or WebFetch.
+
+**Every paid endpoint takes exactly one field: `domain`.** A full URL works too;
+the scheme and path are stripped. Prices below are current at the time of
+writing; the live 402 challenge is the source of truth.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Best For |
+|------|----------|-------|----------|
+| Preview a domain | `https://hosaka-agents.vercel.app/preview` | free | Vendor count and samples before paying |
+| Company summary | `https://hosaka-agents.vercel.app/lookup` | $0.005 | Age, registrar, mail and DNS provider, DMARC, vendor count |
+| Proven vendor stack | `https://hosaka-agents.vercel.app/dossier` | $0.20 | Domain -> every vendor with the record that proves it |
+| Public contacts | `https://hosaka-agents.vercel.app/contacts` | $0.10 | Emails, phones and socials a company publishes |
+| Employees | `https://hosaka-agents.vercel.app/people` | $0.35 | Named people at a domain, with the stack |
+| Decision makers | `https://hosaka-agents.vercel.app/executives` | $0.40 | Owners, founders, C-level, partners, VPs, heads, directors |
+
+Default to `/dossier` when the question is about tools, software or vendors.
+Reach for `/lookup` first only when the domain may not be worth a fuller answer.
+
+## Proven vendor stack
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/dossier -m POST -b '{"domain":"stripe.com"}'
+```
+
+Returns each third-party service with its evidence — an SPF include, a DNS TXT
+verification token, a loaded script — plus registration and certificate facts.
+
+Free preview, no payment, to see the shape first:
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/preview -m POST -b '{"domain":"stripe.com"}'
+```
+
+## Company summary
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/lookup -m POST -b '{"domain":"stripe.com"}'
+```
+
+## People at a domain
+
+Only when the user asked for names. If you already hold a LinkedIn URL or an
+email, use the `data-enrichment` skill instead.
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/executives -m POST -b '{"domain":"stripe.com"}'
+```
+
+## Notes
+
+- Nothing settles unless the answer is produced: a failed lookup is not charged.
+- Settles in USDC on Base, Solana, Polygon, Arbitrum, Algorand and Monad, and in
+  USDG on Robinhood Chain.
+- OpenAPI: https://hosaka-agents.vercel.app/openapi.json

--- a/mcp/skills/technographics/rules/getting-started.md
+++ b/mcp/skills/technographics/rules/getting-started.md
@@ -1,0 +1,44 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash MCP:**
+   ```bash
+   npx agentcash@latest install --client claude-code -y
+   ```
+
+2. **Check wallet:**
+```mcp
+   agentcash.get_balance()
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `agentcash.redeem_invite(code="YOUR_CODE")`
+   - Or call `agentcash.list_accounts()` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "MCP tool not found" | Run install command, restart Claude Code |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |
+| "No match found" | Try different identifiers (email vs LinkedIn) or use search first |
+| "405 Method Not Allowed" | Verify endpoint path matches exactly from Quick Reference table in SKILL.md |
+| "400 Bad Request" | Verify parameter names match exactly from examples in SKILL.md |
+
+## Pricing Reference
+
+| Endpoint | Price |
+|----------|-------|
+| fullenrich/people-search | $0.15 (if results) |
+| fullenrich/company-search | $0.15 (if results) |
+| pdl/people-enrich | $0.28 (if match) |
+| companyenrich/org-enrich | $0.06 |
+| companyenrich/properties-enrich | $0.06 |
+| clado/contacts-enrich | $0.20 |
+| hunter/email-verifier | $0.03 |
+| hunter/email-verifier/jobs/{jobId} | Free (SIWX) |
+| minerva/resolve | $0.02 |
+| minerva/enrich | $0.05 |
+| minerva/validate-emails | $0.01 |

--- a/skills/data-enrichment/SKILL.md
+++ b/skills/data-enrichment/SKILL.md
@@ -58,6 +58,8 @@ ALWAYS use `npx agentcash@latest fetch` for stableenrich.dev endpoints — never
 
 For social media creators, use **stablesocial.dev** — influencer endpoints are not on stableenrich.dev.
 
+For the third-party tools a company runs, proven from its own DNS, use the `technographics` skill. CompanyEnrich returns industry, size and funding; it does not return the software a company uses.
+
 ## Person Enrichment (PDL)
 
 Prefer `profile` (LinkedIn URL) or `email`:

--- a/skills/technographics/SKILL.md
+++ b/skills/technographics/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: technographics
+description: |
+  Find the third-party tools a company runs, from its domain alone, using x402-protected APIs at hosaka-agents.vercel.app. Every vendor comes back with the DNS record or loaded script that proves it, so the answer is checkable rather than asserted.
+
+  USE FOR:
+  - What software, tools or vendors a company uses
+  - Technology stack and technographics from a domain
+  - Company facts when you have a domain but no LinkedIn URL or email
+  - Public contacts, employees or decision makers at a domain
+
+  DO NOT USE FOR:
+  - Industry, headcount or funding — that is CompanyEnrich in data-enrichment
+  - Enriching a known person from a LinkedIn URL or email — that is PDL or FullEnrich in data-enrichment, and they are cheaper at that job
+
+  TRIGGERS:
+  - "tech stack", "technographics", "what tools", "what software"
+  - "vendors", "what is this company built with", "who runs this domain"
+  - "what does [company] use", "decision makers at"
+metadata:
+  version: 1.0
+---
+
+# Technographics with x402 APIs
+
+Use the agentcash CLI to access Hosaka at hosaka-agents.vercel.app. Domain in,
+proven vendors out.
+
+Complementary to `data-enrichment`: CompanyEnrich returns industry, size and
+funding; these endpoints return the tools a company actually runs. PDL and
+FullEnrich need a LinkedIn URL or an email before they answer anything, so when
+all you hold is a domain, they cannot help and this can.
+
+## Setup
+
+See [rules/getting-started.md](rules/getting-started.md) for installation and wallet setup.
+
+## Mandatory workflow
+
+Before any hosaka-agents.vercel.app call:
+
+1. `npx agentcash@latest discover https://hosaka-agents.vercel.app`
+2. `npx agentcash@latest check <endpoint-url>` — confirm request fields and pricing
+3. `npx agentcash@latest fetch` with the schema from step 2
+
+ALWAYS use `npx agentcash@latest fetch` for these endpoints — never curl or WebFetch.
+
+**Every paid endpoint takes exactly one field: `domain`.** A full URL works too;
+the scheme and path are stripped. Prices below are current at the time of
+writing; the live 402 challenge is the source of truth.
+
+## Quick Reference
+
+| Task | Endpoint | Price | Best For |
+|------|----------|-------|----------|
+| Preview a domain | `https://hosaka-agents.vercel.app/preview` | free | Vendor count and samples before paying |
+| Company summary | `https://hosaka-agents.vercel.app/lookup` | $0.005 | Age, registrar, mail and DNS provider, DMARC, vendor count |
+| Proven vendor stack | `https://hosaka-agents.vercel.app/dossier` | $0.20 | Domain -> every vendor with the record that proves it |
+| Public contacts | `https://hosaka-agents.vercel.app/contacts` | $0.10 | Emails, phones and socials a company publishes |
+| Employees | `https://hosaka-agents.vercel.app/people` | $0.35 | Named people at a domain, with the stack |
+| Decision makers | `https://hosaka-agents.vercel.app/executives` | $0.40 | Owners, founders, C-level, partners, VPs, heads, directors |
+
+Default to `/dossier` when the question is about tools, software or vendors.
+Reach for `/lookup` first only when the domain may not be worth a fuller answer.
+
+## Proven vendor stack
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/dossier -m POST -b '{"domain":"stripe.com"}'
+```
+
+Returns each third-party service with its evidence — an SPF include, a DNS TXT
+verification token, a loaded script — plus registration and certificate facts.
+
+Free preview, no payment, to see the shape first:
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/preview -m POST -b '{"domain":"stripe.com"}'
+```
+
+## Company summary
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/lookup -m POST -b '{"domain":"stripe.com"}'
+```
+
+## People at a domain
+
+Only when the user asked for names. If you already hold a LinkedIn URL or an
+email, use the `data-enrichment` skill instead.
+
+```bash
+npx agentcash@latest fetch https://hosaka-agents.vercel.app/executives -m POST -b '{"domain":"stripe.com"}'
+```
+
+## Notes
+
+- Nothing settles unless the answer is produced: a failed lookup is not charged.
+- Settles in USDC on Base, Solana, Polygon, Arbitrum, Algorand and Monad, and in
+  USDG on Robinhood Chain.
+- OpenAPI: https://hosaka-agents.vercel.app/openapi.json

--- a/skills/technographics/rules/getting-started.md
+++ b/skills/technographics/rules/getting-started.md
@@ -1,0 +1,44 @@
+# Getting Started
+
+## Setup
+
+1. **Install the agentcash CLI:**
+   ```bash
+   npm install -g agentcash
+   ```
+
+2. **Check wallet:**
+   ```bash
+   npx agentcash@latest balance
+   ```
+
+3. **Fund wallet** (if needed):
+   - Redeem invite: `npx agentcash@latest redeem YOUR_CODE`
+   - Or run `npx agentcash@latest accounts` to get Base or Solana deposit links and wallet addresses
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Command not found" | Run `npm install -g agentcash` |
+| "Insufficient balance" | Fund wallet with USDC |
+| "Payment failed" | Check balance, retry (transient errors) |
+| "No match found" | Try different identifiers (email vs LinkedIn) or use search first |
+| "405 Method Not Allowed" | Verify endpoint path matches exactly from Quick Reference table in SKILL.md |
+| "400 Bad Request" | Verify parameter names match exactly from examples in SKILL.md |
+
+## Pricing Reference
+
+| Endpoint | Price |
+|----------|-------|
+| fullenrich/people-search | $0.15 (if results) |
+| fullenrich/company-search | $0.15 (if results) |
+| pdl/people-enrich | $0.28 (if match) |
+| companyenrich/org-enrich | $0.06 |
+| companyenrich/properties-enrich | $0.06 |
+| clado/contacts-enrich | $0.20 |
+| hunter/email-verifier | $0.03 |
+| hunter/email-verifier/jobs/{jobId} | Free (SIWX) |
+| minerva/resolve | $0.02 |
+| minerva/enrich | $0.05 |
+| minerva/validate-emails | $0.01 |


### PR DESCRIPTION
Complements data-enrichment, does not replace it. CompanyEnrich returns industry, size and funding. PDL and FullEnrich enrich a known person and need a LinkedIn URL or an email. This skill takes a domain and returns every third-party vendor with the DNS record or loaded script that proves it, which is a job no row in the current table covers. The origin passes npx @agentcash/discovery discover with zero errors, and settled on Base today so the catalog has recrawled the output schema. If you would rather keep a single origin, we are happy to wholesale /dossier under stableenrich.dev.